### PR TITLE
fix TypeError when trying to close IDLE connection

### DIFF
--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -1727,7 +1727,7 @@ class IMAPRetrieverBase(RetrieverSkeleton):
 
         try:
             self.conn.untagged_responses = {}
-            self.conn.send('DONE\r\n')
+            self.conn.send(b'DONE\r\n')
             self.conn._command_complete('IDLE', tag)
         except imaplib.IMAP4.error as o:
             return False


### PR DESCRIPTION
One more error I experienced with IDLE connections (I put this in a different PR because #15 ended up being about fixing capabilities in general, hope that's fine with you):

Terminating getmail6 when running persistent connection with IDLE would generate a type error when sending the 'DONE' because the underlying socket will expect a bytes-like object:

```
    File "/usr/lib/python3.8/site-packages/getmailcore/_retrieverbases.py", line 1730, in go_idle
    self.conn.send('DONE\r\n')
    File "/usr/lib/python3.8/imaplib.py", line 323, in send
    self.sock.sendall(data)
    File "/usr/lib/python3.8/ssl.py", line 1201, in sendall
    with memoryview(data) as view, view.cast("B") as byte_view:
  TypeError: memoryview: a bytes-like object is required, not 'str'
```