### PR TITLE
remove references to missing TODO file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ include docs/BUGS
 include docs/CHANGELOG
 include docs/COPYING
 include docs/THANKS
-include docs/TODO
 include docs/getmaildocs.css
 include docs/getmailrc-examples
 include docs/*.1

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
             'docs/BUGS',
             'docs/COPYING',
             'docs/CHANGELOG',
-            'docs/TODO',
             'docs/THANKS',
             'docs/configuration.html',
             'docs/configuration.txt',


### PR DESCRIPTION
Building fails since commit 55564e94, which removed the TODO file. This
commit fixes this by simply  deleting references to this file from both
`MANIFEST.in` and `setup.py`.