### PR TITLE
Remove empty Unknown distribution option: 'install_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
     license='GNU GPL version 2',
     url='http://www.getmail6.org/',
     download_url='https://github.com/getmail6/getmail6/releases',
-    install_requires=[''],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
```
$ python3 setup.py build
/usr/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
```