### PR TITLE
Give PYTHONPATH example

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -482,6 +482,13 @@ $ su
             </a>
             for details.
         </p>
+	   
+	<p>
+	  For example, if the directory getmailcore ends up living in
+	  $HOME/tmp/getmail/lib/python3.8/site-packages/getmailcore ,
+	  then in the shell do: export PYTHONPATH=$HOME/tmp/getmail/lib/python3.8/site-packages .
+	</p>	    
+	    
         <p class="warning">
             Note that setting
             <span class="file">PYTHONPATH</span>


### PR DESCRIPTION
The user might not be online, hence cannot contact python.org to simply figure out the proper directory levels needed in PYTHONPATH.