### PR TITLE
Python 3.9 support -- codec name and timeout argument

### DIFF
--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -525,10 +525,14 @@ class IMAP4_SSL_EXTENDED(imaplib.IMAP4_SSL):
        self.ssl_ciphers = ssl_ciphers
        imaplib.IMAP4_SSL.__init__(self, host, port, keyfile, certfile)
 
-    def open(self, host='', port=imaplib.IMAP4_SSL_PORT):
+    def open(self, host='', port=imaplib.IMAP4_SSL_PORT, timeout=None):
        self.host = host
        self.port = port
        self.sock = socket.create_connection((host, port))
+
+       # Note timeout is available in python 3.9 in native imaplib's/ssl's open, but wrap_socket does not support it.  Keep it for the future.
+       self.timeout = timeout
+
        extra_args = { 'server_hostname': host }
        if self.ssl_version:
            extra_args['ssl_version'] = self.ssl_version

--- a/getmailcore/imap_utf7.py
+++ b/getmailcore/imap_utf7.py
@@ -136,8 +136,7 @@ class StreamWriter(codecs.StreamWriter):
 _codecInfo = codecs.CodecInfo(encoder, decoder, StreamReader, StreamWriter)
 
 def imap4_utf_7(name):
-    if name == 'imap4-utf-7':
+    if name == 'imap4-utf-7' or name == 'imap4_utf_7':
         return _codecInfo
 
 codecs.register(imap4_utf_7)
-


### PR DESCRIPTION
Support python 3.9 with new codec name comparisons (uses underscore instead of dash) and the new timeout argument to open.

Note as specified in the commit, the timeout argument is **not** actually handed due to the monkeypatch not supporting it.  It is just saved and ignored so that the code runs.
