### PR TITLE
use raw bytes for regexes

### DIFF
--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -1567,8 +1567,8 @@ class IMAPRetrieverBase(RetrieverSkeleton):
             return {}
 
         ext = re.search(
-            b'X-GM-THRID (?P<THRID>\d+) X-GM-MSGID (?P<MSGID>\d+)'
-            b' X-GM-LABELS \((?P<LABELS>.*)\) UID',
+            rb'X-GM-THRID (?P<THRID>\d+) X-GM-MSGID (?P<MSGID>\d+)'
+            rb' X-GM-LABELS \((?P<LABELS>.*)\) UID',
             response[0]
         )
         if not ext:


### PR DESCRIPTION
```
/usr/lib/python3.8/site-packages/getmailcore/_retrieverbases.py:1567: DeprecationWarning: invalid escape sequence \d
  b'X-GM-THRID (?P<THRID>\d+) X-GM-MSGID (?P<MSGID>\d+)'
/usr/lib/python3.8/site-packages/getmailcore/_retrieverbases.py:1568: DeprecationWarning: invalid escape sequence \(
  b' X-GM-LABELS \((?P<LABELS>.*)\) UID',
```