### PR TITLE
Comply more closely with the XDG basedir specification

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,3 +1,9 @@
+Version 6.11
+8 December 2020
+    - comply more closely with the XDG basedir specification: allow an
+    unset XDG_CONFIG_HOME environment variable.
+    - Simplify the documentation around the location of the configuration directory.
+
 Version 6.10
 28 November 2020
     - fix #48: handle Header in address_no_brackets using Header.__str__

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -189,10 +189,13 @@ Please refer to the git history regarding who changed what and when in this file
 </p>
 <ol>
     <li>
-        Create a data/configuration directory.  The default is
-        <span class="file">$XDG_CONFIG_HOME/getmail/</span> or
-        <span class="file">$HOME/.getmail/</span>.
-        If you choose a different location, you will need to specify it on the
+        Create a data/configuration directory.  getmail complies
+        with <a href="https://specifications.freedesktop.org/basedir-spec/latest/index.html">the
+        XDG basedir specification</a>; the default is
+        <span class="file">~/.config/getmail/</span>.  For backward
+        compatibility reasons, getmail also
+        checks <span class="file">$HOME/.getmail/</span>.  If you want
+        a different location, you will need to specify it on the
         <a href="#running">getmail command line</a>.
         In general, other users should not be able to read the contents of this
         directory, so you should set the permissions on it appropriately.
@@ -3036,8 +3039,8 @@ type = Filter_TMDA
     <span class="file">getmailrc-account1</span>
     and
     <span class="file">getmailrc-account2</span>)
-    and put them in
-    <span class="file">~/.getmail/</span> or <span class="file">$XDG_CONFIG_HOME/getmail/</span>.
+    and put them in directory
+    <span class="file">~/.config/getmail/</span>.
     Then run getmail as follows:
 </p>
 <pre class="example">

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -91,15 +91,17 @@
    Once getmail is installed, you need to configure it before you can
    retrieve mail with it. Follow these steps:
 
-    1. Create a data/configuration directory. The default is
-       $XDG_CONFIG_HOME/getmail/ or $HOME/.getmail/. If you choose a
-       different location, you will need to specify it on the getmail command
-       line. In general, other users should not be able to read the contents
-       of this directory, so you should set the permissions on it
+    1. Create a data/configuration directory.  getmail complies with
+       the XDG basedir specification; the default is
+       ~/.config/getmail.  For backward compatibility reasons, getmail
+       also checks ~/.getmail/.  If you want a different location, you
+       will need to specify it on the getmail command line.  In
+       general, other users should not be able to read the contents of
+       this directory, so you should set the permissions on it
        appropriately.
 
  mkdir -m 0700 $HOME/.getmail
-        
+
 
     2. Create a configuration file in the configuration/data directory. The
        default name is getmailrc. If you choose a different filename, you
@@ -361,7 +363,7 @@ Creating a getmail rc file
        program.
 
  password_command = ("/path/to/password-retriever", "-p", "myaccount@example.org")
-        
+
 
    All IMAP retriever types also take the following optional parameters:
 
@@ -373,7 +375,7 @@ Creating a getmail rc file
 
  mailboxes = ("INBOX", "INBOX.spam",
      "mailing-lists.model-railroading")
-        
+
 
        Note that the format for hierarchical folder names is determined by
        the IMAP server, not by getmail. Consult your server's documentation
@@ -390,7 +392,7 @@ Creating a getmail rc file
        all mailboxes, you would use:
 
  mailboxes = ALL
-        
+
 
      * use_peek (boolean) — whether to use PEEK to retrieve the message; the
        default is True. IMAP servers typically mark a message as seen if PEEK
@@ -631,7 +633,7 @@ Creating a getmail rc file
        Delivered-To: header field would be specified as:
 
  envelope_recipient = delivered-to:1
-        
+
 
    The MultidropPOP3Retriever also takes the following optional parameters:
 
@@ -818,7 +820,7 @@ Creating a getmail rc file
  [destination]
  type = Maildir
  path = ~/Maildir/
-        
+
 
    The Maildir destination also takes two optional parameters:
 
@@ -862,7 +864,7 @@ Creating a getmail rc file
  [destination]
  type = Mboxrd
  path = ~/inbox
-        
+
 
    The Mboxrd destination also takes two optional parameters:
 
@@ -1655,8 +1657,8 @@ Commandline options
 
    For instance, if you want to retrieve mail from two different mail
    accounts, create a getmail rc file for each of them (named, say,
-   getmailrc-account1 and getmailrc-account2) and put them in ~/.getmail/ or
-   $XDG_CONFIG_HOME/getmail/. Then run getmail as follows:
+   getmailrc-account1 and getmailrc-account2) and put them in
+   directory ~/.config/getmail/. Then run getmail as follows:
 
  $ getmail --rcfile getmailrc-account1 --rcfile getmailrc-account2
 

--- a/docs/getmailrc-examples
+++ b/docs/getmailrc-examples
@@ -2,8 +2,8 @@
 # This file contains various examples of configuration sections to use
 # in your getmail rc file.  You need one file for each mail account you
 # want to retrieve mail from.  These files should be placed in your
-# getmail configuration/data directory 
-# (default: $XDG_CONFIG_HOME/getmail/ or $HOME/.getmail/).
+# getmail configuration/data directory
+# (default: ~/.config/getmail/).
 # If you only need one rc file, name it getmailrc in that directory,
 # and you won't need to supply any commandline options to run getmail.
 #
@@ -266,17 +266,17 @@ arguments = ("-f", "%(sender)", "${HOME}/.mymdarc")
 # Example 12:  xoauth2 example
 # To initialize do:
 #
-# Step1: Create a new OAuth 2.0 Client-ID 
-# 
+# Step1: Create a new OAuth 2.0 Client-ID
+#
 # Go to the google page for „OAuth 2.0 for Mobile & Desktop Apps“
 # https://developers.google.com/identity/protocols/oauth2/native-app
-# 
+#
 # Follow the link to the Credentials page: https://console.developers.google.com/apis/credentials
-# 
+#
 # Create a new client id + secret for your getmail
-# 
+#
 # Step 2: Add the new credentials to the gmail.json template
-# 
+#
 # {"scope": "https://mail.google.com/",
 #  "user": "your-gmail-user@gmail.com",
 #  "client_id": "the new client id",
@@ -286,18 +286,18 @@ arguments = ("-f", "%(sender)", "${HOME}/.mymdarc")
 #  "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
 #  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"}
 #
-# Step 3: excecute:  
+# Step 3: excecute:
 #
 #    getmail-gmail-xoauth-tokens --init /path-to-your-users-getmail-directory/gmail.json
-# 
+#
 # This will give you a URL you need to open in a browser.
 # This will show you your verification code.
-# 
+#
 # getmail-gmail-xoauth-tokens is waiting for you to enter the verification code.
-# Once you enter the code 
-# 
+# Once you enter the code
+#
 # getmail-gmail-xoauth-tokens will update the gmail.json file.
-# 
+#
 # Step 4: Update the `[retriever] `section of the rc file.
 
 [retriever]
@@ -306,5 +306,3 @@ use_xoauth2 = True
 server = imap.gmail.com
 username = your-gmail-user@gmail.com
 password_command = ("getmail-gmail-xoauth-tokens", "/path-to-your-users-getmail-directory/gmail.json")
-
-

--- a/getmail
+++ b/getmail
@@ -83,13 +83,7 @@ def blurb():
     log.info('Copyright (C) 1998-2020 Charles Cazabon and others. '
              'Licensed under %s.\n'%__license__)
 
-try:
-    getmaildir_default = os.path.join(os.environ['XDG_CONFIG_HOME'],'getmail')
-except KeyError:
-    getmaildir_default = '~/.getmail/'
-
 defaults = {
-    'getmaildir' : getmaildir_default,
     'rcfile' : 'getmailrc',
 
     'verbose' : 1,
@@ -482,7 +476,7 @@ def main():
         parser = OptionParser(version='%%prog %s' % __version__)
         parser.add_option(
             '-g', '--getmaildir',
-            dest='getmaildir', action='store', default=defaults['getmaildir'],
+            dest='getmaildir', action='store',
             help='look in DIR for config/data files', metavar='DIR'
         )
         parser.add_option(
@@ -584,10 +578,20 @@ def main():
             s += '%s="%s"' % (attr, pprint.pformat(getattr(options, attr)))
         log.debug('parsed options:  %s\n' % s)
 
-        getmaildir_type = 'Default'
-        if options.getmaildir != defaults['getmaildir']:
+        if options.getmaildir is None:
+            getmaildir_type = 'Default'
+            xdg_config = os.environ.get('XDG_CONFIG_HOME', os.path.join(os.environ["HOME"], ".config"))
+            getmaildir_xdg = os.path.join(xdg_config, 'getmail')
+            getmaildir_home = os.path.join(os.environ["HOME"], ".getmail")
+            if os.path.exists(getmaildir_xdg):
+                getmaildir = getmaildir_xdg
+            elif os.path.exists(getmaildir_home):
+                getmaildir = getmaildir_home
+            else:
+                raise getmailOperationError('Could not find the getmail configuration directory.  mkdir ~/.config/getmail/ or specify an alternate directory with the --getmaildir option.')
+        else:
             getmaildir_type = 'Specified'
-        getmaildir = expand_user_vars(options.getmaildir)
+            getmaildir = expand_user_vars(options.getmaildir)
         if not os.path.exists(getmaildir):
             raise getmailOperationError(
                 '%s config/data dir "%s" does not exist - create '
@@ -609,7 +613,7 @@ def main():
 
         configs = []
         for filename in options.rcfile:
-            path = os.path.join(os.path.expanduser(options.getmaildir),
+            path = os.path.join(os.path.expanduser(getmaildir),
                                 filename)
             log.debug('processing rcfile %s\n' % path)
             if not os.path.exists(path):
@@ -729,7 +733,7 @@ def main():
                         % (path, retriever_type)
                     )
                 retriever_args = {
-                    'getmaildir' : options.getmaildir,
+                    'getmaildir' : getmaildir,
                     'configparser' : configparser,
                 }
                 for (name, value) in configparser.items('retriever'):


### PR DESCRIPTION
Allow an unset XDG_CONFIG_HOME environment variable.

Simplify the documentation around the location of the configuration
directory.