### PR TITLE
Fix unclosed files

### DIFF
--- a/getmail
+++ b/getmail
@@ -655,6 +655,7 @@ def main():
                     configparser.read_file(f)
                 except AttributeError:
                     configparser.readfp(f)
+                f.close()
                 for option in options_bool:
                     log.debug('  looking for option %s ... ' % option)
                     if configparser.has_option('options', option):

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -822,6 +822,7 @@ class RetrieverSkeleton(ConfigurableBase):
                     'skipped malformed line "%r" for %s%s'
                     % (line, logname, os.linesep)
                 )
+        f.close()
         self.log.moreinfo(
             'read %i uids for %s%s'
             % (len(self.oldmail), logname, os.linesep)


### PR DESCRIPTION
This adds close() function calls for the file descriptors of the configuration file and the oldmail file once they are no longer needed.

Leaving stale unclosed file descriptors causes a python warning if one runs e.g. with PYTHONWARNINGS=d.

Fixes #53