### PR TITLE
Wait much longer, and raise an exception when timeout

### DIFF
--- a/getmailcore/baseclasses.py
+++ b/getmailcore/baseclasses.py
@@ -423,10 +423,9 @@ class ForkingBase(object):
 
     def _wait_for_child(self, childpid):
         self.__child_exited.acquire()
-        if not self.__child_exited.wait(3):
-            self.log.warning('stopped waiting for child %d' % childpid)
-            self.__child_pid = childpid
-            self.__child_status = os.WCONTINUED
+        if not self.__child_exited.wait(60):
+            raise getmailOperationError('waiting child pid %d timed out'
+                                        % childpid)
         self.__child_exited.release()
         if self.__child_pid != childpid:
             #self.log.error('got child pid %d, not %d' % (pid, childpid))


### PR DESCRIPTION
Another approach for #64 

Before #52 `getmail6` waits forever for a child to finish, so I think it is better to wait much longer, and raise an exception when timeout.  I'm not sure if 60secs is enough though.  Also I wonder how I should handle the remained child process...