### PR TITLE
Implement a destination that delivers to a local LMTP server

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -1744,7 +1744,7 @@ arguments = (&quot;--strip-forbidden-attachments&quot;, &quot;--recipient=%(reci
     </li>
 </ul>
 <p>
-    The MDA_lmtp destination also takes one optional parameter:
+    The MDA_lmtp destination also takes several optional parameters:
 </p>
 <ul>
     <li>
@@ -1753,6 +1753,13 @@ arguments = (&quot;--strip-forbidden-attachments&quot;, &quot;--recipient=%(reci
         &mdash; the remote port to connect to. Ignored if
         <span class="sample">host</span>
         is a Unix domain socket.
+    </li>
+    <li>
+        fallback
+        (<a href="#parameter-string">string</a>)
+        &mdash; an alternative recipient address to deliver to in case delivery
+        to the intended recipient fails permanently (i.e. with a 5xx status
+        code).
     </li>
 </ul>
 <p>

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -95,6 +95,7 @@ Please refer to the git history regarding who changed what and when in this file
                     <li><a href="configuration.html#destination-maildir">Maildir</a></li>
                     <li><a href="configuration.html#destination-mboxrd">Mboxrd</a></li>
                     <li><a href="configuration.html#destination-mdaexternal">MDA_external</a></li>
+                    <li><a href="configuration.html#destination-mdalmtp">MDA_lmtp</a></li>
                     <li><a href="configuration.html#destination-multidestination">MultiDestination</a></li>
                     <li><a href="configuration.html#destination-multisorter">MultiSorter</a></li>
                     <li><a href="configuration.html#destination-multiguesser">MultiGuesser</a></li>
@@ -1403,6 +1404,10 @@ envelope_recipient = delivered-to:1
         and others.
     </li>
     <li>
+        <a href="#destination-mdalmtp">MDA_lmtp</a>
+        &mdash; deliver messages to an external MDA via the LMTP protocol.
+    </li>
+    <li>
         <a href="#destination-multidestination">MultiDestination</a>
         &mdash; unconditionally deliver messages to multiple destinations
         (maildirs, mbox files, external MDAs, or other destinations).
@@ -1720,6 +1725,52 @@ path = /path/to/mymda
 user = fred
 group = mail
 arguments = (&quot;--strip-forbidden-attachments&quot;, &quot;--recipient=%(recipient)&quot;)
+</pre>
+
+<h4 id="destination-mdalmtp">MDA_lmtp</h4>
+<p>
+    MDA_lmtp delivers messages via LMTP by connecting to a Unix domain or TCP
+    socket. It currently does not support any authentication.
+</p>
+<p>
+    The MDA_lmtp destination takes one required parameter:
+</p>
+<ul>
+    <li>
+        host
+        (<a href="#parameter-string">string</a>)
+        &mdash; the host to connect to. Either a DNS-resolvable hostname, an IP
+        address or absolute path to a Unix domain socket.
+    </li>
+</ul>
+<p>
+    The MDA_lmtp destination also takes one optional parameter:
+</p>
+<ul>
+    <li>
+        port
+        (<a href="#parameter-integer">integer</a>)
+        &mdash; the remote port to connect to. Ignored if
+        <span class="sample">host</span>
+        is a Unix domain socket.
+    </li>
+</ul>
+<p>
+    A configuration connecting to a Dovecot LMTP server might look like this:
+</p>
+<pre class="example">
+[destination]
+type = MDA_lmtp
+host = /run/dovecot/lmtp
+</pre>
+<p>
+    Another example delivering to a remote host on a non-standard port:
+</p>
+<pre class="example">
+[destination]
+type = MDA_lmtp
+host = mail.example.com
+port = 3333
 </pre>
 
 <h4 id="destination-multidestination">MultiDestination</h4>

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -52,6 +52,7 @@
                     *    * Maildir
                          * Mboxrd
                          * MDA_external
+                         * MDA_lmtp
                          * MultiDestination
                          * MultiSorter
                          * MultiGuesser
@@ -788,6 +789,7 @@ Creating a getmail rc file
        fcntl-type locking.
      * MDA_external — use an external message delivery agent (MDA) to deliver
        messages. Typical MDAs include maildrop, procmail, and others.
+     * MDA_lmtp — deliver messages to an external MDA via the LMTP protocol.
      * MultiDestination — unconditionally deliver messages to multiple
        destinations (maildirs, mbox files, external MDAs, or other
        destinations).
@@ -956,6 +958,34 @@ Creating a getmail rc file
  user = fred
  group = mail
  arguments = ("--strip-forbidden-attachments", "--recipient=%(recipient)")
+
+    MDA_lmtp
+
+   MDA_lmtp delivers messages via LMTP by connecting to a Unix domain or TCP
+   socket. It currently does not support any authentication.
+
+   The MDA_lmtp destination takes one required parameter:
+
+     * host (string) — the host to connect to. Either a DNS-resolvable
+       hostname, an IP address or absolute path to a Unix domain socket.
+
+   The MDA_lmtp destination also takes one optional parameter:
+
+     * port (integer) — the remote port to connect to. Ignored if host is a
+       Unix domain socket.
+
+   A configuration connecting to a Dovecot LMTP server might look like this:
+
+ [destination]
+ type = MDA_lmtp
+ host = /run/dovecot/lmtp
+
+   Another example delivering to a remote host on a non-standard port:
+
+ [destination]
+ type = MDA_lmtp
+ host = mail.example.com
+ port = 3333
 
     MultiDestination
 

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -969,10 +969,13 @@ Creating a getmail rc file
      * host (string) — the host to connect to. Either a DNS-resolvable
        hostname, an IP address or absolute path to a Unix domain socket.
 
-   The MDA_lmtp destination also takes one optional parameter:
+   The MDA_lmtp destination also takes several optional parameters:
 
      * port (integer) — the remote port to connect to. Ignored if host is a
        Unix domain socket.
+     * fallback (string) — an alternative recipient address to deliver to in
+       case delivery to the intended recipient fails permanently (i.e. with a
+       5xx status code).
 
    A configuration connecting to a Dovecot LMTP server might look like this:
 


### PR DESCRIPTION
LMTP is [preferred over an LDA][1] to deliver mail to Dovecot mailboxes. Additionally, LMTP functionality has been asked for in various placed across the web, and so far users who required it had to use `fetchmail` or other projects.

*Note*: This code is affected by [bpo-42756][2] and will currently not work on an unpatched Python 3.9+ installation.

I've had this code running for a few weeks now and haven't noticed any issues — however, this getmail instance doesn't really see much traffic. If you spot anything, or want anything done differently, please feel free to comment!

[1]: <https://wiki.dovecot.org/LDA> "LDA - Dovecot Wiki"
[2]: <https://bugs.python.org/issue42756> "smtplib.LMTP.connect() raises TypeError if `timeout` is not specified"