### PR TITLE
allow "=" in ssl_ciphers

### DIFF
--- a/getmailcore/utilities.py
+++ b/getmailcore/utilities.py
@@ -601,7 +601,7 @@ def check_ssl_ciphers(conf):
                 'specifying ssl_ciphers not supported by this installation of '
                 'Python; requires Python 2.7'
             )
-        if re.search(r'[^a-zA-z0-9, :!\-+@]', ssl_ciphers):
+        if re.search(r'[^a-zA-z0-9, :!\-+@=]', ssl_ciphers):
             raise getmailConfigurationError(
                 'invalid character in ssl_ciphers'
             )


### PR DESCRIPTION
This allows setting a cipher list with a non-default seclevel, like:

  `ssl_ciphers = DEFAULT@SECLEVEL=1`

Tested to work when connecting to a server to which the connection would
otherwise fail with:

  `socket error ([SSL: WRONG_SIGNATURE_TYPE] wrong signature type (_ssl.c:1123))`