### PR TITLE
Revert replaced strings (from "2020" to "2021") in docs/CHANGELOG

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -24,63 +24,63 @@ Version 6.13
     - fix #60: Need to refresh the OAuth access token when reconnecting (IMAP IDLE)
 
 Version 6.12
-31 December 2021
+31 December 2020
     - fix #53: unclosed file warnings
     - fix #52: getmail seems to lose its child process and hangs forever (pull #54)
     - documentation improvements (#55, #56)
 
 Version 6.11
-09 December 2021
+09 December 2020
     - comply more closely with the XDG basedir specification: allow an
       unset XDG_CONFIG_HOME environment variable.
     - Simplify the documentation around the location of the configuration directory.
     - fix #49: "'utf-8' codec can't decode" for mbox
 
 Version 6.10
-28 November 2021
+28 November 2020
     - fix #48: handle Header in address_no_brackets using Header.__str__
 
 Version 6.9
-02 November 2021
+02 November 2020
     - fix python 3.9 issues #42 #44
     - fix regex warning #45
     - add usage of Python keyring package in addition to gnomekeyring (#43)
 
 Version 6.8
-07 October 2021
+07 October 2020
     - fix #37: update copyright date and notices
     - fix #39: Slow mail retrieval
     - pull #40: fix UnboundLocalError when socket.error inside POP3_SSL_EXTENDED
 
 Version 6.7
-01 September 2021
+01 September 2020
     - use $XDG_CONFIG_HOME if defined
     - fix pip install (doc/man below site-packages)
     - fix #34: quote only for select
 
 Version 6.6
-29 August 2021
+29 August 2020
     - fix #34: quote mailbox if necessary
     - fix #36: use setuptools, suggest pip to install and uninstall
 
 Version 6.5
-28 August 2021
+28 August 2020
     - fix #23: port getmail-gmail-xoauth-tokens
     - fix #24: TypeError: 'gaierror' object is not subscriptable
     - documentation fixes
 
 Version 6.4
-24 August 2021
+24 August 2020
     - fix #20: mboxrd can't concat str to bytes
     - fix #21: version numbering from 6.0x to 6.x
 
 Version 6.03
-17 August 2021
+17 August 2020
     - fix #14: IDLE not working
     - documentation update
 
 Version 6.02
-12 August 2021
+12 August 2020
     - try to do as little own decoding as possible
     - issue #8
 
@@ -88,7 +88,7 @@ Version 6.01
     - fixes of reported issues on github up to #7
 
 Version 6.00
-02 May 2021
+02 May 2020
     - Make code compatible to Python 3 (losing some backward compatibility)
 
 Version 5.14


### PR DESCRIPTION
These were modified with the bulk copyright year change in the commit dc7a9f8.

