### PR TITLE
Microsoft Office 365/xoauth2

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -659,8 +659,8 @@ mailboxes = ALL
         use_xoauth2
         (<a href="#parameter-boolean">boolean</a>)
         &mdash; whether to use XOAUTH2 for login with the IMAP server.
-        If not set, normal password-based authenticaion is used.  This is
-        currently only supported with Gmail; if anyone extends this to support
+        If not set, normal password-based authenticaion is used.  This currently
+        supports Gmail and Microsoft Office 365; if anyone extends this to support
         other IMAP providers, please let me know so I can include such support
         in getmail.  <strong>Note that using XOAUTH2 is no more secure than a
         regular getmail configuration with a mode 0600 getmailrc file</strong>.

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -417,16 +417,17 @@ Creating a getmail rc file
        http://honk.sigxcpu.org/projects/pykerberos/" for details.
      * use_xoauth2 (boolean) — whether to use XOAUTH2 for login with the IMAP
        server. If not set, normal password-based authenticaion is used. This
-       is currently only supported with Gmail; if anyone extends this to
-       support other IMAP providers, please let me know so I can include such
-       support in getmail. Note that using XOAUTH2 is no more secure than a
-       regular getmail configuration with a mode 0600 getmailrc file. You
-       will need to set password_command as well to tell getmail to invoke
-       the getmail-gmail-xoauth-tokens helper program; that script requires a
-       positional argument to tell it where to read the initial tokens from
-       and where it writes the access and refresh tokens to, and the file
-       requires manual initial setup. This functionality was contributed by
-       Stefan Krah, who has additional information about using it here.
+       currently supports Gmail and Microsoft Office 365; if anyone extends
+       this to support other IMAP providers, please let me know so I can
+       include such support in getmail. Note that using XOAUTH2 is no more
+       secure than a regular getmail configuration with a mode 0600 getmailrc
+       file. You will need to set password_command as well to tell getmail to
+       invoke the getmail-gmail-xoauth-tokens helper program; that script
+       requires a positional argument to tell it where to read the initial
+       tokens from and where it writes the access and refresh tokens to, and
+       the file requires manual initial setup. This functionality was
+       contributed by Stefan Krah, who has additional information about using
+       it here.
      * imap_search, imap_on_delete (string) — imap_search is the second
        parameter of Python's IMAP search. Set
 

--- a/docs/getmailrc-examples
+++ b/docs/getmailrc-examples
@@ -263,7 +263,7 @@ path = /path/to/my-mda
 arguments = ("-f", "%(sender)", "${HOME}/.mymdarc")
 
 #
-# Example 12:  xoauth2 example
+# Example 12: Gmail xoauth2 example
 # To initialize do:
 #
 # Step1: Create a new OAuth 2.0 Client-ID
@@ -306,3 +306,77 @@ use_xoauth2 = True
 server = imap.gmail.com
 username = your-gmail-user@gmail.com
 password_command = ("getmail-gmail-xoauth-tokens", "/path-to-your-users-getmail-directory/gmail.json")
+
+#
+# Example 13: Microsoft Office 365 xoauth2 example
+# To initialize do:
+#
+# Step1: Create App Registration in Azure
+#
+# In a browser, open https://portal.azure.com
+# Select "Manage Azure Active Directory" (use the search if needed)
+# Select "App Registrations"
+# Select "New Registration"
+# Enter a project name, eg "getmail".
+# Select "Accounts in this organizational directory only (Single tenant)" from "Supported account types"
+# Enter "http://localhost" for "Redirect URI"
+# Select "Register"
+#
+# Now, from the new App's details page, make a note of:
+# * client_id
+# * tenant_id
+# (These are in the "Essentials" section.)
+#
+# Next create a secret by selecting "Certificates and secrets"
+# Select "New client secret"
+# * Description: password
+# * Expires: select preferred expiry date
+# Make a note of:
+# * client_secret
+# It is available by selecting "Value".
+#
+# Next add permissions:
+#
+# Select "API permissions", then "Add a permission".
+# Select "Microsoft Graph"
+# Select "Delegated permissions"
+# Select the following permissions:
+# * IMAP.AccessAsUser.All
+# * POP.AccessAsUser.All
+# * SMTP.Send
+# Select "Add permissions"
+
+# Step 2: Add the new credentials to the microsoft.json template
+#
+# {"scope": "https://outlook.office365.com/IMAP.AccessAsUser.All https://outlook.office365.com/POP.AccessAsUser.All https://outlook.office365.com/SMTP.Send offline_access",
+#  "user": "firstname.lastname@example.com",
+#  "client_id": "<client_id>",
+#  "client_secret": "<secret>",
+#  "token_uri": "https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token",
+#  "auth_uri": "https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/authorize",
+#  "redirect_uri": "http://localhost"}
+#
+# Step 3: excecute:
+#
+#    getmail-gmail-xoauth-tokens --init /path-to-your-users-getmail-directory/microsoft.json
+#
+# This will give you a URL you need to open in a browser.
+# This will show you your verification code.
+# Note: The code will be present in the address bar of your web browser. You will
+# need to find, copy and paste the long "code" parameter's value from your brower's URL bar.
+# (You only need to do this once.)
+#
+# getmail-gmail-xoauth-tokens is waiting for you to enter the verification code.
+# Once you enter the code
+#
+# getmail-gmail-xoauth-tokens will update the microsoft.json file. The json file
+# will now contain the required token.
+#
+# Step 4: Update the `[retriever] `section of the rc file.
+
+[retriever]
+type = SimpleIMAPSSLRetriever
+use_xoauth2 = True
+server = outlook.office365.com
+username = firstname.lastname@example.com
+password_command = ("getmail-gmail-xoauth-tokens", "/path-to-your-users-getmail-directory/microsoft.json")

--- a/getmail-gmail-xoauth-tokens
+++ b/getmail-gmail-xoauth-tokens
@@ -20,6 +20,7 @@
 # Derived from oauth2.py (https://github.com/google/gmail-oauth2-tools).
 # Heavily modified and rewritten by Stefan Krah.
 #
+# Works for Microsoft Office 365 in addition to Gmail.
 
 
 import os


### PR DESCRIPTION
Show how to use getmail to retrieve mail from Microsoft Office 365
when using xoauth2 authentication.

Provide steps for obtaining required user parameters (client_id,
tenant_id, etc). Also provide example getmail configuration showing
how to use them.

Works with the existing "getmail-gmail-xoauth-tokens" script.