### PR TITLE
bugfix for python3 using bytes buffer instead of str

### DIFF
--- a/getmail_maildir
+++ b/getmail_maildir
@@ -59,7 +59,7 @@ def main():
     if not is_maildir(path):
         raise SystemExit('Error: %s is not a maildir' % path)
 
-    msg = Message(fromfile=sys.stdin)
+    msg = Message(fromfile=sys.stdin.buffer)
     if 'SENDER' in os.environ:
         msg.sender = os.environ['SENDER']
     if 'RECIPIENT' in os.environ:


### PR DESCRIPTION
On Debian 11 I ran into this 

```
Delivery error (command getmail_maildir 271452 error (1, Traceback (most recent call last):
  File "/usr/bin/getmail_maildir", line 82, in <module>
    main()
  File "/usr/bin/getmail_maildir", line 62, in main
    msg = Message(fromfile=sys.stdin)
  File "/usr/lib/python3/dist-packages/getmailcore/message.py", line 124, in __init__
    self.__msg = parser.parse(fromfile)
  File "/usr/lib/python3.9/email/parser.py", line 109, in parse
    return self.parser.parse(fp, headersonly)
  File "/usr/lib/python3.9/email/parser.py", line 53, in parse
    data = fp.read(8192)
TypeError: underlying read() should have returned a bytes-like object, not 'str'))
```

I assume getmail_mbox has the same problem, but since I don't have mboxes to test I cannot confirm. This PR fixes this bug but afaik for Python 3 only.