### PR TITLE
Fix random token generation

### DIFF
--- a/getmailcore/utilities.py
+++ b/getmailcore/utilities.py
@@ -20,6 +20,7 @@ import grp
 import getpass
 import subprocess
 import sys
+import secrets
 
 __all__ = [
     'address_no_brackets',
@@ -293,13 +294,7 @@ def deliver_maildir(maildirpath, data, hostname, dcount=None, filemode=0o600):
         info['unique'] = 'M%(usecs)dP%(pid)s' % info
         if info['deliverycount'] is not None:
             info['unique'] += 'Q%(deliverycount)s' % info
-        try:
-            info['unique'] += 'R%s' % ''.join(
-                ['%02x' % ord(char)
-                 for char in open('/dev/urandom').read(8)]
-            )
-        except Exception:
-            pass
+        info['unique'] += 'R%s' % secrets.token_hex(8)
 
         filename = '%(secs)s.%(unique)s.%(hostname)s' % info
         fname_tmp = os.path.join(dir_tmp, filename)


### PR DESCRIPTION
I noticed that with python warnings enabled getmail would complain about an unclosed file /dev/urandom.

The reason is some code in utilities.py generating a random token. This code almost never works in the way it's written, as it is trying to read in ascii mode from /dev/urandom. However the generic exception handler makes this error to be silent.

In any case: The functionality this code tries to achieve - generating a random hex token - can easily be achieved with functionality from the python standard library. The attached patch will replace the token generation with a call to secrets.token_hex(), which does exactly what's needed here.