### PR TITLE
add config parameter to MDA_lmtp to override recipient address (WIP)

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -1804,6 +1804,13 @@ arguments = (&quot;--strip-forbidden-attachments&quot;, &quot;--recipient=%(reci
         to the intended recipient fails permanently (i.e. with a 5xx status
         code).
     </li>
+    <li>
+        override
+        (<a href="#parameter-string">string</a>)
+        &mdash; deliver mail to an alternative recipient address instead of the
+        one given by the envelope or mail headers. Behaviour of the fallback
+        parameter still applies in case delivery fails.
+    </li>
 </ul>
 <p>
     A configuration connecting to a Dovecot LMTP server might look like this:
@@ -1821,6 +1828,17 @@ host = /run/dovecot/lmtp
 type = MDA_lmtp
 host = mail.example.com
 port = 3333
+</pre>
+<p>
+    An example where each mail is delivered to user <em>alice</em>, but if this
+    fails (i.e. their user quota has been reached) it is delivered to <em>bob</em>:
+</p>
+<pre class="example">
+[destination]
+type = MDA_lmtp
+host = mail.example.com
+override = alice
+fallback = bob
 </pre>
 
 <h4 id="destination-multidestination">MultiDestination</h4>

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -1010,6 +1010,9 @@ Creating a getmail rc file
      * fallback (string) — an alternative recipient address to deliver to in
        case delivery to the intended recipient fails permanently (i.e. with a
        5xx status code).
+     * override (string) — deliver mail to an alternative recipient address
+       instead of the one given by the envelope or mail headers. Behaviour of
+       the fallback parameter still applies in case delivery fails.
 
    A configuration connecting to a Dovecot LMTP server might look like this:
 
@@ -1023,6 +1026,15 @@ Creating a getmail rc file
  type = MDA_lmtp
  host = mail.example.com
  port = 3333
+
+   An example where each mail is delivered to user alice, but if this fails
+   (i.e. their user quota has been reached) it is delivered to bob:
+
+ [destination]
+ type = MDA_lmtp
+ host = mail.example.com
+ override = alice
+ fallback = bob
 
     MultiDestination
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.8'
 
 services:
   mailserver:
-    image: docker.io/mailserver/docker-mailserver:latest
+    build:
+      context: /tmp/mailserver
+    image: docker-mailserver-custom
     hostname: ${HOSTNAME}
     domainname: ${DOMAINNAME}
     container_name: ${CONTAINER_NAME}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3.8'
 services:
   mailserver:
     build:
-      context: /tmp/mailserver
-    image: docker-mailserver-custom
+      context: /tmp/mailserver/docker-mailserver-getmail6test
+    image: docker-mailserver-getmail6test
     hostname: ${HOSTNAME}
     domainname: ${DOMAINNAME}
     container_name: ${CONTAINER_NAME}
@@ -26,6 +26,8 @@ services:
       - ENABLE_CLAMAV=1
       - ENABLE_SPAMASSASSIN=1
       - DOVECOT_TLS="yes"
+      - PSS=test
+      - TESTEMAIL=address@domain.tld
     cap_add:
       #- NET_ADMIN
       - SYS_PTRACE

--- a/test/docker-mailserver-getmail6test/Dockerfile
+++ b/test/docker-mailserver-getmail6test/Dockerfile
@@ -1,0 +1,21 @@
+FROM ghcr.io/docker-mailserver/docker-mailserver:9.0.1
+
+RUN apt-get update && apt-get -y install \
+        git \
+        iputils-ping \
+        make \
+        nmap \
+        procmail \
+        python-pip \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash getmail
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+# use our own entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
+# from https://github.com/docker-mailserver/docker-mailserver/blob/014dddafbc2e329b7c35aada498eeba8b940d83d/Dockerfile#L291
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/test/docker-mailserver-getmail6test/Dockerfile
+++ b/test/docker-mailserver-getmail6test/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get -y install \
         python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /bin/bash getmail
+# add our user to postfix group so we can access dovecot's LMTP unix socket
+RUN useradd -m -s /bin/bash getmail \
+    && usermod -a -G postfix getmail
 
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/test/docker-mailserver-getmail6test/entrypoint.sh
+++ b/test/docker-mailserver-getmail6test/entrypoint.sh
@@ -5,6 +5,7 @@ if ! /usr/local/bin/listmailuser 2>/dev/null | egrep "^${TESTEMAIL}$" > /dev/nul
     echo "* creating mailuser"
     # the env vars are set by our docker-compose.yml
     /usr/local/bin/addmailuser "${TESTEMAIL}" "${PSS}"
+    /usr/local/bin/addmailuser "other-user@example.com" "${PSS}"
 fi
 
 if [[ ! -e "/tmp/docker-mailserver/ssl" ]]; then

--- a/test/docker-mailserver-getmail6test/entrypoint.sh
+++ b/test/docker-mailserver-getmail6test/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# add user if it doesn't exist
+if ! /usr/local/bin/listmailuser 2>/dev/null | egrep "^${TESTEMAIL}$" > /dev/null; then
+    echo "* creating mailuser"
+    # the env vars are set by our docker-compose.yml
+    /usr/local/bin/addmailuser "${TESTEMAIL}" "${PSS}"
+fi
+
+if [[ ! -e "/tmp/docker-mailserver/ssl" ]]; then
+    echo "* generating SSL certificate"
+    /tmp/docker-mailserver/self_sign.sh
+fi
+
+# run original init
+exec /usr/bin/dumb-init -- $@

--- a/test/prepare_test.sh
+++ b/test/prepare_test.sh
@@ -517,6 +517,46 @@ d_lmtp_test_py() {
 d_docker "lmtp_test_py $@"
 }
 
+lmtp_test_unix_socket() {
+  RETRIEVER=$1
+  PORT=$2
+if head `which getmail` | grep 'python3' ; then
+  nc 0.0.0.0 25 << EOF
+HELO mail.localhost
+MAIL FROM: a-user@example.com
+RCPT TO: ${TESTEMAIL}
+DATA
+From: a-user@example.com
+To: ${TESTEMAIL}
+Subject: lmtp_test_unix_socket_x
+This is the test text:
+я αβ один süße créme in Tromsœ.
+.
+QUIT
+EOF
+  sleep 1
+  mail_clean
+  cat > /home/getmail/getmail <<EOF
+[retriever]
+type = ${RETRIEVER}
+server = localhost
+username = $TESTEMAIL
+port = $PORT
+password = $PSS
+[destination]
+type = MDA_lmtp
+# use docker-mailserver/dovecot's lmtp listener
+host = /var/run/dovecot/lmtp
+[options]
+read_all = True
+delete = True
+EOF
+fi
+}
+d_lmtp_test_unix_socket() {
+d_docker "lmtp_test_unix_socket $@"
+}
+
 lmtp_test_override() {
   RETRIEVER=$1
   PORT=$2

--- a/test/prepare_test.sh
+++ b/test/prepare_test.sh
@@ -151,6 +151,7 @@ function copy_tests() {
     yes | cp -f $GETMAIL6REPO/test/self_sign.sh /tmp/mailserver/config/
 
     cd  /tmp/mailserver/config
+    echo "need sudo to rm /tmp/mailserver/config/getmail6"
     sudo rm -rf getmail6
     cp -R $GETMAIL6REPO getmail6
 }
@@ -464,7 +465,7 @@ d_multisorter_test() {
 d_docker "multisorter_test $@"
 }
 
-lmtp_test() {
+lmtp_test_py() {
   RETRIEVER=$1
   PORT=$2
 if head `which getmail` | grep 'python3' ; then
@@ -478,8 +479,6 @@ username = $TESTEMAIL
 port = $PORT
 password = $PSS
 [destination]
-#type = Maildir
-#path = $MAILDIRIN/
 type = MDA_lmtp
 host = 127.0.0.1
 port = 23218
@@ -507,8 +506,35 @@ EOF
   python3 /home/getmail/lmtpd.py &
 fi
 }
-d_lmtp_test() {
-d_docker "lmtp_test $@"
+d_lmtp_test_py() {
+d_docker "lmtp_test_py $@"
+}
+
+lmtp_test_unix_socket() {
+  RETRIEVER=$1
+  PORT=$2
+if head `which getmail` | grep 'python3' ; then
+  testmail
+  mail_clean
+  cat > /home/getmail/getmail <<EOF
+[retriever]
+type = ${RETRIEVER}
+server = localhost
+username = $TESTEMAIL
+port = $PORT
+password = $PSS
+[destination]
+type = MDA_lmtp
+# use docker-mailserver/dovecot's lmtp listener
+host = /var/run/dovecot/lmtp
+[options]
+read_all = True
+delete = True
+EOF
+fi
+}
+d_lmtp_test_unix_socket() {
+d_docker "lmtp_test_unix_socket $@"
 }
 
 imap_search() {

--- a/test/prepare_test.sh
+++ b/test/prepare_test.sh
@@ -502,7 +502,7 @@ class LMTPChannel(SMTPChannel):
 class LMTPServer(SMTPServer):
   def __init__(self, localaddr, remoteaddr):
     SMTPServer.__init__(self, localaddr, remoteaddr)
-  def process_message(self, peer, mailfrom, rcpttos, data):
+  def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
     return
   def handle_accept(self):
     conn, addr = self.accept()
@@ -515,33 +515,6 @@ fi
 }
 d_lmtp_test_py() {
 d_docker "lmtp_test_py $@"
-}
-
-lmtp_test_unix_socket() {
-  RETRIEVER=$1
-  PORT=$2
-if head `which getmail` | grep 'python3' ; then
-  testmail
-  mail_clean
-  cat > /home/getmail/getmail <<EOF
-[retriever]
-type = ${RETRIEVER}
-server = localhost
-username = $TESTEMAIL
-port = $PORT
-password = $PSS
-[destination]
-type = MDA_lmtp
-# use docker-mailserver/dovecot's lmtp listener
-host = /var/run/dovecot/lmtp
-[options]
-read_all = True
-delete = True
-EOF
-fi
-}
-d_lmtp_test_unix_socket() {
-d_docker "lmtp_test_unix_socket $@"
 }
 
 lmtp_test_override() {

--- a/test/self_sign.sh
+++ b/test/self_sign.sh
@@ -45,11 +45,11 @@ function create_demo_CA() {
 EOF
     SUBJCA="${SUBJ}for.test.ca"
     CONFIG="-subj $SUBJCA -passin pass:$PSS -passout pass:$PSS"
-    openssl req $CONFIG -new -keyout $CATOP/private/cakey.pem -out $CATOP/careq.pem
+    openssl req $CONFIG -new -keyout $CATOP/private/cakey.pem -out $CATOP/careq.pem 2> /dev/null
     openssl ca -subj $SUBJCA -passin pass:$PSS -create_serial \
             -out $CATOP/cacert.pem $CADAYS -batch \
             -keyfile $CATOP/private/cakey.pem \
-            -selfsign -extensions v3_ca -infiles $CATOP/careq.pem
+            -selfsign -extensions v3_ca -infiles $CATOP/careq.pem 2> /dev/null
 }
 
 # persists
@@ -77,14 +77,14 @@ function generate_self_signed() {
     # Create an unpassworded private key and create an unsigned public key certificate
     openssl req -subj "${SUBJ}{$FQDN}" \
         -new -nodes -keyout "${SSL_CFG_PATH}"/"${FQDN}"-key.pem \
-        -out "${SSL_CFG_PATH}"/"${FQDN}"-req.pem -days 3652
+        -out "${SSL_CFG_PATH}"/"${FQDN}"-req.pem -days 3652 2> /dev/null
 
     [[ -f "${SSL_CFG_PATH}"/"${FQDN}"-key.pem ]] && echo "${FQDN}-key.pem is there"
     [[ -f "${SSL_CFG_PATH}"/"${FQDN}"-req.pem ]] && echo "${FQDN}-req.pem is there"
 
     # Sign the public key certificate with CA certificate
     openssl ca -out "${SSL_CFG_PATH}"/"${FQDN}"-cert.pem -batch \
-        -passin pass:$PSS -infiles "${SSL_CFG_PATH}"/"${FQDN}"-req.pem
+        -passin pass:$PSS -infiles "${SSL_CFG_PATH}"/"${FQDN}"-req.pem 2> /dev/null
 
     [[ -f "${SSL_CFG_PATH}"/"${FQDN}"-cert.pem ]] && echo "${FQDN}-cert.pem is there"
 

--- a/test/test_getmail_with_docker_mailserver.bats
+++ b/test/test_getmail_with_docker_mailserver.bats
@@ -178,9 +178,37 @@ bats_lmtp_test_py() {
   assert_success
 }
 
+bats_check_lmtp_delivery() {
+  run d_grep_mail "$TESTGREP"
+  assert_failure # expect no mail because the mail was delivered to $TESTEMAIL's vmail mailbox
+  run d_maildir_clean_retrieve IMAP
+  assert_success # retrieves the mail we delivered using LMTP into our maildir
+  run d_grep_mail "$TESTGREP"
+  assert_success
+}
+
 bats_lmtp_test_unix_socket() {
   run d_lmtp_test_unix_socket "$@"
   run d_retrieve
+  assert_success
+  bats_check_lmtp_delivery
+}
+
+bats_lmtp_test_override() {
+  run d_lmtp_test_override "$@"
+  run d_retrieve
+  assert_success
+  bats_check_lmtp_delivery
+  run d_grep_mail "Subject: lmtp_test_override_x"
+  assert_success
+}
+
+bats_lmtp_test_override_fallback() {
+  run d_lmtp_test_override_fallback "$@"
+  run d_retrieve
+  assert_success
+  bats_check_lmtp_delivery
+  run d_grep_mail "Subject: lmtp_test_override_fallback_x"
   assert_success
 }
 
@@ -188,6 +216,8 @@ bats_lmtp_test_unix_socket() {
 @test "MDA_lmtp" {
 bats_lmtp_test_py "SimpleIMAPRetriever 143"
 bats_lmtp_test_unix_socket "SimpleIMAPRetriever 143"
+bats_lmtp_test_override "SimpleIMAPRetriever 143"
+bats_lmtp_test_override_fallback "SimpleIMAPRetriever 143"
 }
 
 bats_imap_search() {

--- a/test/test_getmail_with_docker_mailserver.bats
+++ b/test/test_getmail_with_docker_mailserver.bats
@@ -172,15 +172,22 @@ bats_multisorter_test "MultidropIMAPRetriever 143"
 bats_multisorter_test "MultidropIMAPSSLRetriever 993"
 }
 
-bats_lmtp_test() {
-  run d_lmtp_test "$@"
+bats_lmtp_test_py() {
+  run d_lmtp_test_py "$@"
+  run d_retrieve
+  assert_success
+}
+
+bats_lmtp_test_unix_socket() {
+  run d_lmtp_test_unix_socket "$@"
   run d_retrieve
   assert_success
 }
 
 
 @test "MDA_lmtp" {
-bats_lmtp_test "SimpleIMAPRetriever 143"
+bats_lmtp_test_py "SimpleIMAPRetriever 143"
+bats_lmtp_test_unix_socket "SimpleIMAPRetriever 143"
 }
 
 bats_imap_search() {

--- a/test/test_getmail_with_docker_mailserver.bats
+++ b/test/test_getmail_with_docker_mailserver.bats
@@ -187,13 +187,6 @@ bats_check_lmtp_delivery() {
   assert_success
 }
 
-bats_lmtp_test_unix_socket() {
-  run d_lmtp_test_unix_socket "$@"
-  run d_retrieve
-  assert_success
-  bats_check_lmtp_delivery
-}
-
 bats_lmtp_test_override() {
   run d_lmtp_test_override "$@"
   run d_retrieve
@@ -215,7 +208,6 @@ bats_lmtp_test_override_fallback() {
 
 @test "MDA_lmtp" {
 bats_lmtp_test_py "SimpleIMAPRetriever 143"
-bats_lmtp_test_unix_socket "SimpleIMAPRetriever 143"
 bats_lmtp_test_override "SimpleIMAPRetriever 143"
 bats_lmtp_test_override_fallback "SimpleIMAPRetriever 143"
 }

--- a/test/test_getmail_with_docker_mailserver.bats
+++ b/test/test_getmail_with_docker_mailserver.bats
@@ -187,6 +187,15 @@ bats_check_lmtp_delivery() {
   assert_success
 }
 
+bats_lmtp_test_unix_socket() {
+  run d_lmtp_test_unix_socket "$@"
+  run d_retrieve
+  assert_success
+  bats_check_lmtp_delivery
+  run d_grep_mail "Subject: lmtp_test_unix_socket_x"
+  assert_success
+}
+
 bats_lmtp_test_override() {
   run d_lmtp_test_override "$@"
   run d_retrieve
@@ -208,6 +217,7 @@ bats_lmtp_test_override_fallback() {
 
 @test "MDA_lmtp" {
 bats_lmtp_test_py "SimpleIMAPRetriever 143"
+bats_lmtp_test_unix_socket "SimpleIMAPRetriever 143"
 bats_lmtp_test_override "SimpleIMAPRetriever 143"
 bats_lmtp_test_override_fallback "SimpleIMAPRetriever 143"
 }


### PR DESCRIPTION
My [use case](https://github.com/spezifisch/docker-dovecot-getmail) is that I want to run multiple instances of getmail6 to fetch emails using IMAP with IDLE.
The fetched emails are delivered to the same user on the dovecot server using LMTP.

Out of the box this doesn't work because `MDA_lmtp` uses the recipient address inside the email, which contains the address of the remote account. The dovecot server doesn't (and shouldn't) know about those addresses, so I think we need a way to override the recipient address to a custom value.

For example:

```ini
[destination]
type = MDA_lmtp
host = dovecot
override = some_user
```

With this PR the email would be sent to the recipient `some_user` on the dovecot server instead of whatever the email headers say.

If you think this feature could be merged, I would add the documentation and tests for this.