### PR TITLE
fix ignored return value when retrying after SMTPServerDisconnected exception

### DIFF
--- a/getmailcore/destinations.py
+++ b/getmailcore/destinations.py
@@ -721,7 +721,7 @@ class MDA_lmtp(DeliverySkeleton):
             else:
                 self.log.info('Lost connection to LMTP server, reconnecting')
                 self.__connect()
-                self.__send(msg, sender, recipient, __retrying=True)
+                return self.__send(msg, sender, recipient, __retrying=True)
         except smtplib.SMTPRecipientsRefused as err:
             rcpt = err.recipients
         except smtplib.SMTPException as err:


### PR DESCRIPTION
This is *not* related to #105 but could also lead to problems when:

* the connection drops at the first delivery try
* the mail is refused by the server at the second try
