### PR TITLE
Fix for #129

### DIFF
--- a/getmailcore/destinations.py
+++ b/getmailcore/destinations.py
@@ -592,6 +592,9 @@ class MDA_external(DeliverySkeleton, ForkingBase):
 
       ignore_stderr (boolean, optional) - if set, getmail will not consider the
             program writing to stderr to be an error.  The default is False.
+            
+      pipe_stdout (boolean, optional) - if set, stdout from external command
+            will be forwared to stdout of getmail.  The default is True. 
     '''
     _confitems = (
         ConfInstance(name='configparser', required=False),
@@ -602,6 +605,7 @@ class MDA_external(DeliverySkeleton, ForkingBase):
         ConfBool(name='allow_root_commands', required=False, default=False),
         ConfBool(name='unixfrom', required=False, default=False),
         ConfBool(name='ignore_stderr', required=False, default=False),
+        ConfBool(name='pipe_stdout', required=False, default=True),
     )
 
     def initialize(self):
@@ -654,7 +658,10 @@ class MDA_external(DeliverySkeleton, ForkingBase):
             lambda o,e: self._deliver_command(
                 msg, msginfo, delivered_to, received, o, e)
             )
-
+        
+        if self.conf['pipe_stdout'] and child.out:
+            self.log.info('%s\n' % (''.join(map(chr, child.out))))
+        
         self.log.debug('command %s %d exited %d\n'
                        % (self.conf['command'], child.childpid, child.exitcode))
         if child.exitcode:

--- a/getmailcore/destinations.py
+++ b/getmailcore/destinations.py
@@ -594,7 +594,7 @@ class MDA_external(DeliverySkeleton, ForkingBase):
             program writing to stderr to be an error.  The default is False.
             
       pipe_stdout (boolean, optional) - if set, stdout from external command
-            will be forwared to stdout of getmail.  The default is True. 
+            will be forwarded to stdout of getmail.  The default is True. 
     '''
     _confitems = (
         ConfInstance(name='configparser', required=False),


### PR DESCRIPTION
Adds a new option "pipe_stdout" to the [destination] settings block. Settings it to "True" will pipe it to stdout of getmail, "False" will drop stdout from external MDA (like it was before). Default is set to "True" now as this is how fetchmail does.
TODO: Docs needs to be updated, too.