### PR TITLE
Partial fix for #135

### DIFF
--- a/docs/getmailrc-examples
+++ b/docs/getmailrc-examples
@@ -359,7 +359,7 @@ password_command = ("getmail-gmail-xoauth-tokens", "/path/to/your/users/getmail/
 # Select "New Registration"
 # Enter a project name, eg "getmail".
 # Select "Accounts in this organizational directory only (Single tenant)" from "Supported account types"
-# Enter "http://localhost" for "Redirect URI"
+# Select type "Web" and enter "http://localhost:8083" for "Redirect URI"
 # Select "Register"
 #
 # Now, from the new App's details page, make a note of:


### PR DESCRIPTION
Adds missing hint to select type "Web" within the redirect-URI settings in Azure's app-registration. (See issue #135). Adds missing port number to redirect-URI.