### PR TITLE
Ignore directories in getmailrcdir

### DIFF
--- a/getmails
+++ b/getmails
@@ -57,7 +57,8 @@ if $para ; then
            ! endwith "$file" '#' && \
            ! startswith "$file" 'oldmail-' && \
            ! endwith "$file" '.swp' && \
-           ! endwith "$file" '.bak' ; then
+           ! endwith "$file" '.bak' && \
+           [ -f "$file" ]; then
 	    $rcfiles --rcfile "$file" "$@" &
 	    pids="$pids $!"
         fi
@@ -79,7 +80,8 @@ else
            ! endwith "$file" '#' && \
            ! startswith "$file" 'oldmail-' && \
            ! endwith "$file" '.swp' && \
-           ! endwith "$file" '.bak' ; then
+           ! endwith "$file" '.bak' && \
+           [ -f "$file" ]; then
             rcfiles="$rcfiles --rcfile \"$file\""
         fi
     done


### PR DESCRIPTION
getmails stops with the message "Error: dirname is not a file", if there is a directory in getmailrcdir. 

With this diff, it ignores the directories and the other files in getmailrcdir are processed.