### PR TITLE
Enable overriding the prompt parameter in the XOAUTH URL

### DIFF
--- a/getmail-gmail-xoauth-tokens
+++ b/getmail-gmail-xoauth-tokens
@@ -87,7 +87,10 @@ class OAuth2(object):
         params['redirect_uri'] = 'http://localhost:' + str(port) + '/'
         params['response_type'] = 'code'
         params['access_type'] = 'offline'
-        params['prompt'] = 'consent'
+        if 'prompt' in self.data:
+            params['prompt'] = self.data['prompt']
+        else:
+            params['prompt'] = 'consent'
         return '%s?%s' % (self.data['auth_uri'], self.query(params))
 
     def get_response(self, url, params):


### PR DESCRIPTION
Herewith I would like to propose a small extension. For certain scenarios within XOAUTH authentication with MS365 tenants it is necessary to change the URL for retrieving the verification code. Specifically, it is about the "prompt" URL parameter. So far, this parameter is set to "consent". This leads to situations where the user on whose behalf the authentication is to be performed does not have admin permissions, resulting in this user getting a prompt to log in as an administrator, even if the rights have already been granted at the enterprise level. In these cases, setting "prompt" to "login", for example, is useful. This pull request proposes to make the value of "prompt" configurable via the json file, assuming the previous fixed value of "consent" in the absence of the value in the json file. For other possible values, please refer to the documentation[1] at Microsoft.

[1] https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow