### PR TITLE
Add GitHub Action to spellcheck and lint Python code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+# https://github.com/codespell-project/codespell
+# https://beta.ruff.rs
+name: lint
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell
+    - run: ruff --format=github .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,9 @@
 name: lint
 on:
   push:
-    branches: [main, master]
-  pull_request:
   #  branches: [main, master]
+  pull_request:
+    branches: [main, master]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@
 name: lint
 on:
   push:
-  #  branches: [main, master]
+    branches: [main, master]
   pull_request:
     branches: [main, master]
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+  #  branches: [main, master]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -77,7 +77,7 @@ Version 6.17
     - #69: skip_imap_fetch_size. IMAP requests size, making davmail download all the messages every time, making it slow
     - #81: Allow having IMAP message IDs recorded in headers (if received=True in config)
     - #82: Add branding to Received header
-    - #85: Discuss content of oldmail filese in FAQ
+    - #85: Discuss content of oldmail files in FAQ
 
 Version 6.16
 13 May 2021
@@ -341,7 +341,7 @@ Version 4.46.0
 Version 4.45.0
 30 March 2014
     -perform hostname-vs-certificate matching of SSL certificate if validating
-    the certifcate.  Thanks: "mancha".
+    the certificate.  Thanks: "mancha".
     -fix missing plaintext versions of documentation.
 
 Version 4.44.0

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -562,7 +562,7 @@ type = <span class="meta">typename</span>
             <li>from the <span class="file">password</span> configuration item in the getmailrc file</li>
             <li>by running an arbitrary command specified with the password_command parameter (see below)</li>
             <li>from Python keyring if available</li>
-            <li>if <a href="#use_netrc">use_netrc</a> option is True, fom a .netrc file
+            <li>if <a href="#use_netrc">use_netrc</a> option is True, from a .netrc file
             <li>if not found via any of the above methods, getmail will prompt for the password when run</li>
         </ol>
         To store your POP/IMAP account password into the Python keyring, ensure
@@ -1171,7 +1171,7 @@ envelope_recipient = delivered-to:1
     </li>
 </ul>
 <p>
-    The MultidropPOP3SSLRetriever class alo takes the following optional
+    The MultidropPOP3SSLRetriever class also takes the following optional
     parameters:
 </p>
 <ul>
@@ -2246,7 +2246,7 @@ user = log
     you want to filter on.
 </p>
 <p>
-    If you want to filter based on arbitrary message critera, like &quot;What address
+    If you want to filter based on arbitrary message criteria, like &quot;What address
     is in the To: header field?&quot; or &quot;Who is the message from?&quot;, then
     use the filtering MDA of your choice, called from a getmail
     <a href="#destination-mdaexternal">MDA_external</a> destination.
@@ -2628,7 +2628,7 @@ localpart_translate = ('mailhostaccount-', '')
         (<a href="#parameter-integer">integer</a>)
         &mdash; if set, getmail will process a maximum of this number of
         messages before closing the session with the server.  This can be useful
-        if your network or the server is particuarly unreliable.  Default: 0,
+        if your network or the server is particularly unreliable.  Default: 0,
         which means not to enable this feature.
     </li>
     <li>
@@ -2763,7 +2763,7 @@ message_log = ~/.getmail/log
         &mdash; supply the message to an external program, which can then modify
         the message in any fashion.  The program must print the modified message
         to stdout. getmail reads the modified message from the program in this
-        fasion before proceeding to the next filter or destination.  Messages
+        fashion before proceeding to the next filter or destination.  Messages
         can be dropped by having the filter return specific exit codes.
     </li>
     <li>

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -346,7 +346,7 @@ Creating a getmail rc file
          2. by running an arbitrary command specified with the
             password_command parameter (see below)
          3. from Python keyring if available
-         4. if use_netrc option is True, fom a .netrc file
+         4. if use_netrc option is True, from a .netrc file
          5. if not found via any of the above methods, getmail will prompt
             for the password when run
        To store your POP/IMAP account password into the Python keyring,
@@ -702,7 +702,7 @@ Creating a getmail rc file
      * envelope_recipient (string) — see MultidropPOP3Retriever for
        definition.
 
-   The MultidropPOP3SSLRetriever class alo takes the following optional
+   The MultidropPOP3SSLRetriever class also takes the following optional
    parameters:
 
      * use_apop (boolean) — see SimplePOP3Retriever for definition.
@@ -1293,7 +1293,7 @@ Creating a getmail rc file
    agent (MDA) (such as maildrop or procmail), if and only if the message
    recipient is the criteria you want to filter on.
 
-   If you want to filter based on arbitrary message critera, like "What
+   If you want to filter based on arbitrary message criteria, like "What
    address is in the To: header field?" or "Who is the message from?", then
    use the filtering MDA of your choice, called from a getmail MDA_external
    destination.
@@ -1494,7 +1494,7 @@ Creating a getmail rc file
      * max_messages_per_session (integer) — if set, getmail will process a
        maximum of this number of messages before closing the session with the
        server. This can be useful if your network or the server is
-       particuarly unreliable. Default: 0, which means not to enable this
+       particularly unreliable. Default: 0, which means not to enable this
        feature.
      * delivered_to (boolean) — if set, getmail adds a Delivered-To: header
        field to the message. If unset, it will not do so. Default: True. Note
@@ -1570,7 +1570,7 @@ Creating a getmail rc file
      * Filter_external — supply the message to an external program, which can
        then modify the message in any fashion. The program must print the
        modified message to stdout. getmail reads the modified message from
-       the program in this fasion before proceeding to the next filter or
+       the program in this fashion before proceeding to the next filter or
        destination. Messages can be dropped by having the filter return
        specific exit codes.
      * Filter_TMDA — run the message through the tmda-filter program for use

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -795,7 +795,7 @@ Please refer to the git history regarding who changed what and when in this file
 <p>
     Confusion often arises among novice users about the difference between the
     message header and the message envelope; they seem to believe that they
-    are not independant.  This appears to be an artifact of their use of
+    are not independent.  This appears to be an artifact of their use of
     simple-minded GUI mail user agents (MUAs) that do not allow them to set
     the envelopes of their messages explicitly, but instead simply use the
     contents of the From: header field as the envelope sender address, and

--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -536,7 +536,7 @@ Configuring getmail
 
    Confusion often arises among novice users about the difference between the
    message header and the message envelope; they seem to believe that they
-   are not independant. This appears to be an artifact of their use of
+   are not independent. This appears to be an artifact of their use of
    simple-minded GUI mail user agents (MUAs) that do not allow them to set
    the envelopes of their messages explicitly, but instead simply use the
    contents of the From: header field as the envelope sender address, and any

--- a/docs/getmailrc-examples
+++ b/docs/getmailrc-examples
@@ -287,7 +287,7 @@ arguments = ("-f", "%(sender)", "${HOME}/.mymdarc")
 #
 # A client_id and client_secret identify a web app or a desktop app.
 # getmail-gmail-xoauth-tokens
-# creates a local server with loopback redirect (127.0.0.1) to get the autorization.
+# creates a local server with loopback redirect (127.0.0.1) to get the authorization.
 # https://developers.google.com/identity/protocols/oauth2/native-app#redirect-uri_loopback
 #
 # To initialize do:
@@ -397,7 +397,7 @@ password_command = ("getmail-gmail-xoauth-tokens", "/path/to/your/users/getmail/
 #  "auth_uri": "https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/authorize",
 #  "redirect_uri": "http://localhost"}
 #
-# Step 3: excecute:
+# Step 3: execute:
 #
 #    getmail-gmail-xoauth-tokens --init /path-to-your-users-getmail-directory/microsoft.json
 #

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -262,7 +262,7 @@ Please refer to the git history regarding who changed what and when in this file
 <p>
     By default, getmail will not invoke external commands (in destinations or
     filters) when it is running with root privileges, for security reasons.
-    See the documenation for possible solutions.
+    See the documentation for possible solutions.
 </p>
 
 <h4 id="errmsg-config-no-command" class="errmsg">Configuration error: no such command <span class="meta">path</span></h4>

--- a/docs/troubleshooting.txt
+++ b/docs/troubleshooting.txt
@@ -165,7 +165,7 @@ Error messages
 
    By default, getmail will not invoke external commands (in destinations or
    filters) when it is running with root privileges, for security reasons.
-   See the documenation for possible solutions.
+   See the documentation for possible solutions.
 
     Configuration error: no such command path
 

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -1579,7 +1579,7 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                     self._mboxuids[msgid] = r['uid']
                     self._mboxuidorder.append(msgid)
                     self.msgnum_by_msgid[msgid] = None
-                    self.msgsizes[msgid] = (0 if 
+                    self.msgsizes[msgid] = (0 if
                         self.app_options['skip_imap_fetch_size']
                                         else int(r['rfc822.size']))
 

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -209,7 +209,7 @@ def _ipaddress_match(cert_ipaddress, host_ip):
     (section 1.7.2 - "Out of Scope").
     """
     # OpenSSL may add a trailing newline to a subjectAltName's IP address,
-    # commonly woth IPv6 addresses. Strip off trailing \n.
+    # commonly with IPv6 addresses. Strip off trailing \n.
     ip = _inet_paton(cert_ipaddress.rstrip())
     return ip == host_ip
 
@@ -748,7 +748,7 @@ class RetrieverSkeleton(ConfigurableBase):
 
       __str__(self) - return a simple string representing the class instance.
 
-      _getmsglist(self) - retieve a list of all available messages, and store
+      _getmsglist(self) - retrieve a list of all available messages, and store
                           unique message identifiers in the dict
                           self.msgnum_by_msgid.
                           Message identifiers must be unique and persistent
@@ -759,7 +759,7 @@ class RetrieverSkeleton(ConfigurableBase):
       _delmsgbyid(self, msgid) - delete a message from the message store based
                                  on its message identifier.
 
-      _getmsgbyid(self, msgid) - retreive and return a message from the message
+      _getmsgbyid(self, msgid) - retrieve and return a message from the message
                                  store based on its message identifier.  The
                                  message is returned as a Message() class
                                  object. The message will have additional data
@@ -1579,7 +1579,7 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                     self._mboxuids[msgid] = r['uid']
                     self._mboxuidorder.append(msgid)
                     self.msgnum_by_msgid[msgid] = None
-                    self.msgsizes[msgid] = (0 if
+                    self.msgsizes[msgid] = (0 if 
                         self.app_options['skip_imap_fetch_size']
                                         else int(r['rfc822.size']))
 

--- a/getmailcore/baseclasses.py
+++ b/getmailcore/baseclasses.py
@@ -50,7 +50,7 @@ else:
 
 #######################################
 def run_command(command, args):
-    # Simple subprocess wrapper for running a command and fetching its exit 
+    # Simple subprocess wrapper for running a command and fetching its exit
     # status and output/stderr.
     if args is None:
         args = []

--- a/getmailcore/destinations.py
+++ b/getmailcore/destinations.py
@@ -601,9 +601,9 @@ class MDA_external(DeliverySkeleton, ForkingBase):
 
       ignore_stderr (boolean, optional) - if set, getmail will not consider the
             program writing to stderr to be an error.  The default is False.
-            
+
       pipe_stdout (boolean, optional) - if set, stdout from external command
-            will be forwarded to stdout of getmail.  The default is True. 
+            will be forwarded to stdout of getmail.  The default is True.
     '''
     _confitems = (
         ConfInstance(name='configparser', required=False),
@@ -670,10 +670,10 @@ class MDA_external(DeliverySkeleton, ForkingBase):
                 )
         except getmailOperationError as oe:
             raise getmailDeliveryError( 'delivery %s child operation error: %s' % (self, oe) )
-        
+
         if self.conf['pipe_stdout'] and child.out:
             self.log.info('%s\n' % (''.join(map(chr, child.out))))
-        
+
         self.log.debug('command %s %d exited %d\n'
                        % (self.conf['command'], child.childpid, child.exitcode))
         if child.exitcode:
@@ -975,7 +975,7 @@ class MultiSorter(MultiSorterBase):
                ("jason@example.org", "/home/jasonk/Maildir/"),
                ("sales@example.org", "/home/karlyk/Mail/sales"),
                ("abuse@(example.org|example.net)", "/home/kellyw/Mail/abuse/"),
-               ("^(jeff|jefferey)(\.s(mith)?)?@.*$", "[jeff-mail-delivery]"),
+               ("^(jeff|jefferey)(\\.s(mith)?)?@.*$", "[jeff-mail-delivery]"),
                ("^.*@(mail.)?rapinder.example.org$", "/home/rapinder/Maildir/")
                )
 

--- a/getmailcore/imap_utf7.py
+++ b/getmailcore/imap_utf7.py
@@ -28,7 +28,7 @@ From the RFC:
          the use of "~" in some servers as a home directory indicator.
 
       5) UTF-7 permits multiple alternate forms to represent the same
-         string; in particular, printable US-ASCII chararacters can be
+         string; in particular, printable US-ASCII characters can be
          represented in encoded form.
 
    In modified UTF-7, printable US-ASCII characters except for "&"

--- a/getmailcore/logging.py
+++ b/getmailcore/logging.py
@@ -4,7 +4,7 @@
 
 '''Logging support for getmail.
 
-The new standard Python libary module logging didn't cut it for me; it doesn't
+The new standard Python library module logging didn't cut it for me; it doesn't
 seem capable of handling some very simple requirements like logging messages of
 a certain level to one fd, and other messages of higher levels to a different fd
 (i.e. info to stdout, warnings to stderr).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,94 @@
+[tool.codespell]
+ignore-words-list = "fpr,hepler,loos,te,thrid"
+
+[tool.ruff]
+select = [
+  "AIR",       # Airflow
+  "ASYNC",     # flake8-async
+  "B",         # flake8-bugbear
+  "C90",       # McCabe cyclomatic complexity
+  "DTZ",       # flake8-datetimez
+  "E",         # pycodestyle
+  "F",         # Pyflakes
+  "FA",        # flake8-future-annotations
+  "FLY",       # flynt
+  "ICN",       # flake8-import-conventions
+  "INT",       # flake8-gettext
+  "ISC",       # flake8-implicit-str-concat
+  "PL",        # Pylint
+  "PT",        # flake8-pytest-style
+  "PYI",       # flake8-pyi
+  "RSE",       # flake8-raise
+  "RUF",       # Ruff-specific rules
+  "T10",       # flake8-debugger
+  "TCH",       # flake8-type-checking
+  "TID",       # flake8-tidy-imports
+  "W",         # pycodestyle
+  "YTT",       # flake8-2020
+  # "A",       # flake8-builtins
+  # "ANN",     # flake8-annotations
+  # "ARG",     # flake8-unused-arguments
+  # "BLE",     # flake8-blind-except
+  # "C4",      # flake8-comprehensions
+  # "COM",     # flake8-commas
+  # "D",       # pydocstyle
+  # "DJ",      # flake8-django
+  # "EM",      # flake8-errmsg
+  # "ERA",     # eradicate
+  # "EXE",     # flake8-executable
+  # "FBT",     # flake8-boolean-trap
+  # "FIX",     # flake8-fixme
+  # "G",       # flake8-logging-format
+  # "I",       # isort
+  # "INP",     # flake8-no-pep420
+  # "N",       # pep8-naming
+  # "NPY",     # NumPy-specific rules
+  # "PD",      # pandas-vet
+  # "PGH",     # pygrep-hooks
+  # "PIE",     # flake8-pie
+  # "PLR091",  # Pylint Refactor just for max-args, max-branches, etc.
+  # "PTH",     # flake8-use-pathlib
+  # "Q",       # flake8-quotes
+  # "RET",     # flake8-return
+  # "S",       # flake8-bandit
+  # "SIM",     # flake8-simplify
+  # "SLF",     # flake8-self
+  # "T20",     # flake8-print
+  # "TD",      # flake8-todos
+  # "TRY",     # tryceratops
+  # "UP",      # pyupgrade
+]
+ignore = [
+  "B007",
+  "B904",
+  "E401",
+  "E402",
+  "E711",
+  "E712",
+  "E713",
+  "E722",
+  "E731",
+  "F401",
+  "F403",
+  "F405",
+  "F841",
+  "PLR0402",
+  "PLW2901",
+  "RUF005",
+]
+line-length = 142
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 16
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["bytes", "int", "str"]
+max-args = 11
+max-branches = 20
+max-returns = 7
+max-statements = 56
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402"]
+"test/*" = ["S101"]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if '--show-default-install-dirs' in args:
     print('  Python modules : %s' % distutils.sysconfig.get_python_lib())
     print('  documentation :  %s' % GETMAILDOCDIR)
     print('  man(1) pages :   %s' % GETMAILMANDIR)
-    raise SystemExit()
+    raise SystemExit
 
 setup(
     name='getmail6',


### PR DESCRIPTION
Test results: https://github.com/cclauss/getmail6/actions

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)