### PR TITLE
Allow to customize 'redirect_uri'

### DIFF
--- a/getmail-gmail-xoauth-tokens
+++ b/getmail-gmail-xoauth-tokens
@@ -83,8 +83,9 @@ class OAuth2(object):
         return '&'.join(lst)
 
     def code_url(self, port):
-        params = self.copy('scope', 'client_id')
-        params['redirect_uri'] = 'http://localhost:' + str(port) + '/'
+        params = self.copy('scope', 'client_id', 'redirect_uri')
+        if not params['redirect_uri']:
+            params['redirect_uri'] = 'http://localhost:' + str(port) + '/'
         params['response_type'] = 'code'
         params['access_type'] = 'offline'
         if 'prompt' in self.data:
@@ -115,8 +116,9 @@ class OAuth2(object):
             json.dump(self.data, f)
 
     def init_tokens(self, code, port):
-        params = self.copy('user', 'client_id', 'client_secret')
-        params['redirect_uri'] = 'http://localhost:' + str(port) + '/'
+        params = self.copy('user', 'client_id', 'client_secret', 'redirect_uri')
+        if not params['redirect_uri']:
+            params['redirect_uri'] = 'http://localhost:' + str(port) + '/'
         params['code'] = code
         params['grant_type'] = 'authorization_code'
 
@@ -150,23 +152,26 @@ if __name__ == '__main__':
     auth = OAuth2(args.tokenfile)
 
     if args.init:
+        interrupted = False
         print("Visit this url to obtain a verification code:")
         print("    %s\n" % auth.code_url(args.port))
-        print("Press Ctrl+C if you are installing getmail on a device without a browser.")
-        oauthd = OAuthRedirectServer(args.port)
-        try:
-            oauthd.handle_request()
-            auth.init_tokens(oauthd.oauth_code, args.port)
-        except:
-            #handles offline usage (for headless servers)
+        if not auth.copy('redirect_uri'):
+            print("Press Ctrl+C if you are installing getmail on a device without a browser.")
+            oauthd = OAuthRedirectServer(args.port)
+            try:
+                oauthd.handle_request()
+                auth.init_tokens(oauthd.oauth_code, args.port)
+            except:
+                interrupted = True
+            finally:
+                oauthd.server_close()
+        if auth.copy('redirect_uri') or interrupted:
             print("Please paste the response from the address bar of the browser you used for the url above:")
             codeinput = input()
             response = urlparse.urlparse(codeinput)
             query_string = urlparse.parse_qs(response.query)
             code = query_string["code"][0]
-            auth.init_tokens(code,args.port) 
-        finally:
-            oauthd.server_close()
+            auth.init_tokens(code,args.port)
         print("\naccess token\n")
 
     print("%s" % auth.token())


### PR DESCRIPTION
Commit 97f0d54 ("Add local server to capture OAuth2 redirect.") improves user experience. However, it seems our Office365 instance need a specific value for redirect_uri. Typically, this configuration was used to work:

  {
    ...
    "redirect_uri": "https://login.microsoftonline.com/common/oauth2/nativeclient"
  }

and now Office server returns:

    AADSTS50011: The redirect URI 'http://localhost:8083/' specified in
    the request does not match the redirect URIs configured for the
    application 'xxxxxxxxxxx'. Make sure the redirect URI sent in the
    request matches one added to your application in the Azure portal.
    Navigate to https://aka.ms/redirectUriMismatchError to learn more
    about how to fix this.

Close #178