### PR TITLE
feat: mark read after retrieved

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -649,7 +649,7 @@ mailboxes = ALL
         use_kerberos
         (<a href="#parameter-boolean">boolean</a>)
         &mdash; whether to use Kerberos authentication with the IMAP server.
-        If not set, normal password-based authenticaion is used.  Note that when
+        If not set, normal password-based authentication is used.  Note that when
         you use Kerberos authentication, it is up to you to ensure you have a
         valid Kerberos ticket (perhaps by running a ticket-renewing agent such
         as <a href="http://www.eyrie.org/~eagle/software/kstart/">kstart</a> or similar).
@@ -662,7 +662,7 @@ mailboxes = ALL
         use_xoauth2
         (<a href="#parameter-boolean">boolean</a>)
         &mdash; whether to use XOAUTH2 for login with the IMAP server.
-        If not set, normal password-based authenticaion is used.  This currently
+        If not set, normal password-based authentication is used.  This currently
         supports Gmail and Microsoft Office 365; if anyone extends this to support
         other IMAP providers, please let me know so I can include such support
         in getmail.  <strong>Note that using XOAUTH2 is no more secure than a

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -2674,6 +2674,14 @@ localpart_translate = ('mailhostaccount-', '')
         </span>
         Default: False.
     </li>
+    <li>
+        mark_read
+        (<a href="#parameter-boolean">boolean</a>)
+        &mdash; if set, getmail will mark messages as read after retrieving
+	them instead of delete. It is setting both imap_search = "\Unseen"
+	and imap_on_delete = "\Seen" synonymously and override.
+        Default: False.
+    </li>
 </ul>
 <p>
     Most users will want to either enable the
@@ -2683,8 +2691,8 @@ localpart_translate = ('mailhostaccount-', '')
     option (to only retrieve previously-unread mail).
 </p>
 <p>
-    The verbose, read_all, and delete parameters can be overridden at run time
-    with
+    The verbose, read_all, delete, and mark_read parameters can be overridden
+    at run time with
     <a href="#running">commandline options</a>.
 </p>
 

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -1455,6 +1455,10 @@ Creating a getmail rc file
        mails, if something went wrong, like the server dying. Default: False.
      * skip_imap_fetch_size (boolean) — will skip fetching RFC822.SIZE. This
        speeds up mail checks, particularly with a davmail proxies.
+     * mark_read: (boolean) — if set, getmail will mark messages as read after
+       retrieving them instead of delete. It is setting both
+       imap_search = "\Unseen" and imap_on_delete = "\Seen" synonymously
+       and override.
 
  skip_imap_fetch_size
 
@@ -1522,8 +1526,8 @@ Creating a getmail rc file
    after retrieving it), or disable the read_all option (to only retrieve
    previously-unread mail).
 
-   The verbose, read_all, and delete parameters can be overridden at run time
-   with commandline options.
+   The verbose, read_all, delete, and mark_read parameters can be overridden at
+   run time with commandline options.
 
     [options] example
 

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -410,7 +410,7 @@ Creating a getmail rc file
        containing the name of the selected mailbox that the message was
        retrieved from. This is on by default, but can be disabled.
      * use_kerberos (boolean) — whether to use Kerberos authentication with
-       the IMAP server. If not set, normal password-based authenticaion is
+       the IMAP server. If not set, normal password-based authentication is
        used. Note that when you use Kerberos authentication, it is up to you
        to ensure you have a valid Kerberos ticket (perhaps by running a
        ticket-renewing agent such as kstart or similar). This feature
@@ -418,7 +418,7 @@ Creating a getmail rc file
        installed; check your OS distribution or see
        http://honk.sigxcpu.org/projects/pykerberos/" for details.
      * use_xoauth2 (boolean) — whether to use XOAUTH2 for login with the IMAP
-       server. If not set, normal password-based authenticaion is used. This
+       server. If not set, normal password-based authentication is used. This
        currently supports Gmail and Microsoft Office 365; if anyone extends
        this to support other IMAP providers, please let me know so I can
        include such support in getmail. Note that using XOAUTH2 is no more

--- a/getmail
+++ b/getmail
@@ -170,6 +170,9 @@ def go(configs, idle, accounts=[]):
                             'be retrieved each time getmail is run\n'
                             % retriever)
 
+        if options['mark_read']:
+            options['delete'] = True
+
         oplevel = options['verbose']
         logverbose = options['message_log_verbose']
         now = int(time.time())
@@ -178,7 +181,6 @@ def go(configs, idle, accounts=[]):
         msgs_skipped = 0
         if options['message_log_syslog']:
             syslog.openlog('getmail', 0, syslog.LOG_MAIL)
-        mark_read = options['mark_read']
         try:
             if not idling:
                 log.info('%s:\n' % retriever)
@@ -327,23 +329,6 @@ def go(configs, idle, accounts=[]):
                                 log.debug('    deleted\n')
                                 info += ', deleted'
                                 logline += ', deleted'
-
-                        if retrieve and mark_read:
-                            try:
-                                retriever.mark_msg_read(msgid)
-                                log.debug('    marked read\n')
-                                info += ', marked read'
-                                logline += ', marked read'
-                            except getmailOperationError as o:
-                                # mark_read = False
-                                #log.warn('%s: operation error (%s)\n' % (configfile, o))
-                                log.warn('%s: mark read failed this operation may not be supported. ignoring\n' % configfile)
-                                if options['logfile']:
-                                    options['logfile'].write('getmailOperationError warning (%s)' % o)
-                                if options['message_log_syslog']:
-                                    syslog.syslog(syslog.LOG_WARN,
-                                                  'getmailOperationError warning (%s)' % o)
-                                pass
 
                     except getmailDeliveryError as o:
                         errorexit = True
@@ -664,11 +649,6 @@ If no flag is given "\Seen" is assumed.
             dest='override_imap_id_extension', action='store_true',
             help='enable IMAP ID extension (RFC 2971)'
         )
-        overrides.add_option(
-            '-R', '--mark-read',
-            dest='override_mark_read', action='store_true',
-            help='mark read after retrieve'
-        )
         parser.add_option_group(overrides)
 
         parser.add_option(
@@ -893,6 +873,17 @@ If no flag is given "\Seen" is assumed.
                     'getmaildir' : getmaildir,
                     'configparser' : configparser,
                 }
+
+                mark_read = configparser.get('options', 'mark_read')
+                if mark_read:
+                    override_imap = [',']
+                    flags,search = imap_search_flags(override_imap)
+                    if flags:
+                        imap_override['imap_on_delete'] = '('+' '.join(flags)+')'
+                        ## options.override_delete = True # commented out, to avoid skipping when both read_all and mark_read are set
+                    if search:
+                        imap_override['imap_search'] = '('+' '.join(search)+')'
+
                 for (name, value) in configparser.items('retriever'):
                     if name in ('type', 'configparser'):
                         continue
@@ -1036,12 +1027,15 @@ If no flag is given "\Seen" is assumed.
                 )
 
             # Apply overrides from commandline
-            for option in ('read_all', 'delete', 'verbose', 'fingerprint', 'to_oldmail_on_each_mail', 'mark_read'):
+            for option in ('read_all', 'delete', 'verbose', 'fingerprint', 'to_oldmail_on_each_mail'):
                 val = getattr(options, 'override_%s' % option)
                 if val is not None:
                     log.debug('overriding option %s from commandline %s\n'
                               % (option, val))
                     config[option] = val
+            val = getattr(options, 'mark_read')
+            if val is not None:
+                config['mark_read'] = val
 
             if config['verbose'] > 2:
                 config['verbose'] = 2

--- a/getmail
+++ b/getmail
@@ -50,6 +50,7 @@ options_bool = (
     'use_netrc',
     'skip_imap_fetch_size',
     'to_oldmail_on_each_mail',
+    'mark_read',
 )
 options_int = (
     'delete_after',
@@ -112,6 +113,7 @@ defaults = {
     'netrc_file' : None,
     'skip_imap_fetch_size' : False,
     'imap_id_extension': False,
+    'mark_read': False,
 }
 
 
@@ -176,6 +178,7 @@ def go(configs, idle, accounts=[]):
         msgs_skipped = 0
         if options['message_log_syslog']:
             syslog.openlog('getmail', 0, syslog.LOG_MAIL)
+        mark_read = options['mark_read']
         try:
             if not idling:
                 log.info('%s:\n' % retriever)
@@ -324,6 +327,23 @@ def go(configs, idle, accounts=[]):
                                 log.debug('    deleted\n')
                                 info += ', deleted'
                                 logline += ', deleted'
+
+                        if retrieve and mark_read:
+                            try:
+                                retriever.mark_msg_read(msgid)
+                                log.debug('    marked read\n')
+                                info += ', marked read'
+                                logline += ', marked read'
+                            except getmailOperationError as o:
+                                # mark_read = False
+                                #log.warn('%s: operation error (%s)\n' % (configfile, o))
+                                log.warn('%s: mark read failed this operation may not be supported. ignoring\n' % configfile)
+                                if options['logfile']:
+                                    options['logfile'].write('getmailOperationError warning (%s)' % o)
+                                if options['message_log_syslog']:
+                                    syslog.syslog(syslog.LOG_WARN,
+                                                  'getmailOperationError warning (%s)' % o)
+                                pass
 
                     except getmailDeliveryError as o:
                         errorexit = True
@@ -644,6 +664,11 @@ If no flag is given "\Seen" is assumed.
             dest='override_imap_id_extension', action='store_true',
             help='enable IMAP ID extension (RFC 2971)'
         )
+        overrides.add_option(
+            '-R', '--mark-read',
+            dest='override_mark_read', action='store_true',
+            help='mark read after retrieve'
+        )
         parser.add_option_group(overrides)
 
         parser.add_option(
@@ -762,6 +787,7 @@ If no flag is given "\Seen" is assumed.
                 'netrc_file' : defaults['netrc_file'],
                 'skip_imap_fetch_size' : defaults['skip_imap_fetch_size'],
                 'imap_id_extension': defaults['imap_id_extension'],
+                'mark_read': defaults['mark_read'],
             }
             # Python's ConfigParser .getboolean() couldn't handle booleans in
             # the defaults. Submitted a patch; they fixed it a different way.
@@ -1010,7 +1036,7 @@ If no flag is given "\Seen" is assumed.
                 )
 
             # Apply overrides from commandline
-            for option in ('read_all', 'delete', 'verbose', 'fingerprint', 'to_oldmail_on_each_mail'):
+            for option in ('read_all', 'delete', 'verbose', 'fingerprint', 'to_oldmail_on_each_mail', 'mark_read'):
                 val = getattr(options, 'override_%s' % option)
                 if val is not None:
                     log.debug('overriding option %s from commandline %s\n'

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -795,9 +795,6 @@ class RetrieverSkeleton(ConfigurableBase):
                                   For IMAP imap_on_delete allows other flag:
                                   return True if `Deleted` is among the flags.
 
-      _mark_msg_read_by_id(self, msgid) - mark a message as read based on its
-                                          message identifier.
-
       _getmsgbyid(self, msgid) - retrieve and return a message from the message
                                  store based on its message identifier.  The
                                  message is returned as a Message() class
@@ -1049,11 +1046,6 @@ class RetrieverSkeleton(ConfigurableBase):
         self.deleted[msgid] = deleted
         return deleted
 
-    def mark_msg_read(self, msgid):
-        if not self.__initialized:
-            raise getmailOperationError('not initialized')
-        self._mark_msg_read_by_id(msgid)
-
     def run_password_command(self):
         command = self.conf['password_command'][0]
         args = self.conf['password_command'][1:]
@@ -1182,9 +1174,6 @@ class POP3RetrieverBase(RetrieverSkeleton):
         msgnum = self._getmsgnumbyid(msgid)
         self.conn.dele(msgnum)
         return True
-
-    def _mark_msg_read_by_id(self, msgid):
-        pass
 
     def _getmsgbyid(self, msgid):
         self.log.debug('msgid %s' % msgid + os.linesep)
@@ -1678,18 +1667,7 @@ class IMAPRetrieverBase(RetrieverSkeleton):
             response = self._parse_imapuidcmdresponse(
                 'STORE', uid, 'FLAGS', flag
             )
-            return 'Deleted' in flags
-        except imaplib.IMAP4.error as o:
-            raise getmailOperationError('IMAP error (%s)' % o)
-
-    def _mark_msg_read_by_id(self, msgid):
-        self.log.trace()
-        try:
-            uid = self._getmboxuidbymsgid(msgid)
-            response = self._parse_imapuidcmdresponse(
-                'STORE', uid, '+FLAGS',
-                r'\Seen'
-            )
+            return 'Deleted' in flag
         except imaplib.IMAP4.error as o:
             raise getmailOperationError('IMAP error (%s)' % o)
 

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -795,6 +795,9 @@ class RetrieverSkeleton(ConfigurableBase):
                                   For IMAP imap_on_delete allows other flag:
                                   return True if `Deleted` is among the flags.
 
+      _mark_msg_read_by_id(self, msgid) - mark a message as read based on its
+                                          message identifier.
+
       _getmsgbyid(self, msgid) - retrieve and return a message from the message
                                  store based on its message identifier.  The
                                  message is returned as a Message() class
@@ -1046,6 +1049,11 @@ class RetrieverSkeleton(ConfigurableBase):
         self.deleted[msgid] = deleted
         return deleted
 
+    def mark_msg_read(self, msgid):
+        if not self.__initialized:
+            raise getmailOperationError('not initialized')
+        self._mark_msg_read_by_id(msgid)
+
     def run_password_command(self):
         command = self.conf['password_command'][0]
         args = self.conf['password_command'][1:]
@@ -1174,6 +1182,9 @@ class POP3RetrieverBase(RetrieverSkeleton):
         msgnum = self._getmsgnumbyid(msgid)
         self.conn.dele(msgnum)
         return True
+
+    def _mark_msg_read_by_id(self, msgid):
+        pass
 
     def _getmsgbyid(self, msgid):
         self.log.debug('msgid %s' % msgid + os.linesep)
@@ -1668,6 +1679,17 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                 'STORE', uid, 'FLAGS', flag
             )
             return 'Deleted' in flags
+        except imaplib.IMAP4.error as o:
+            raise getmailOperationError('IMAP error (%s)' % o)
+
+    def _mark_msg_read_by_id(self, msgid):
+        self.log.trace()
+        try:
+            uid = self._getmboxuidbymsgid(msgid)
+            response = self._parse_imapuidcmdresponse(
+                'STORE', uid, '+FLAGS',
+                r'\Seen'
+            )
         except imaplib.IMAP4.error as o:
             raise getmailOperationError('IMAP error (%s)' % o)
 


### PR DESCRIPTION
I add an option (`mark_read`) to mailbox settings and command line option (`-R`) to override it.

Currently, it's only has the effect on imap accounts, since POP3 is quite simple and it mostly mark read automatically (I have not tried on POP3 account, so I leave it with just 'pass'). 

the command option is `-R` as below:

```text
Overrides:
    ....
    -R, --mark-read     mark read after retrieve
```

and the option in config file is `mark_read = true|false` (default is false as before) as below:

```
[options]
mark_read = true
```
