### PR TITLE
fix: remove Seen flags even when mark_read option is set, to avoid unneccessary setting Seen flag

### DIFF
--- a/getmail
+++ b/getmail
@@ -850,8 +850,8 @@ If no flag is given "\Seen" is assumed.
                         defaultopt[option_org] = val
                 imap_override = {}
                 flags,search = imap_search_flags(options.imap_search_n_set)
-                if defaultopt['mark_read'] and ('\\SEEN' not in {x.upper() for x in flags}):
-                    flags += ['\\SEEN']
+                #if defaultopt['mark_read'] and ('\\SEEN' not in {x.upper() for x in flags}):
+                #    flags += ['\\SEEN']
                 if flags:
                     imap_override['imap_on_delete'] = '('+' '.join(flags)+')'
                     options.override_delete = True # intention given by -s,


### PR DESCRIPTION
I think the `Seen` flag should not be added into imap_search_flags, even when `mark_read` option added.

The logic is, I think, when I set `mark_read` option manually, since it's false by default, I just want to and need the Unseen mails.

These days I noticed that getmail always fetch the old (seen) messages like below, it's thousands, and it made slow and network traffic, since gmail and other email SPs provide large volume email services.

```text
$ time getmail
SimpleIMAPSSLRetriever:xxx@outlook.com@outlook.office365.com:993:
  ...
  [INBOX] msg 2360/2367 (25681 bytes)
  [INBOX] msg 2361/2367 (124612 bytes)
  [INBOX] msg 2362/2367 (4375 bytes)
  [INBOX] msg 2363/2367 (4159 bytes)
  [INBOX] msg 2364/2367 (4024 bytes)
  [INBOX] msg 2365/2367 (11082 bytes)
  [INBOX] msg 2366/2367 (8523 bytes)
  [INBOX] msg 2367/2367 (184397 bytes)
  0 messages (0 bytes) retrieved, 2367 skipped
SimpleIMAPSSLRetriever:xxx@qq.com@imap.qq.com:993:
  ...
  [INBOX] msg 2353/2367 (143769 bytes)
  [INBOX] msg 2354/2367 (4395 bytes)
  [INBOX] msg 2355/2367 (4215 bytes)
  [INBOX] msg 2356/2367 (4022 bytes)
  [INBOX] msg 2357/2367 (5868 bytes)
  [INBOX] msg 2358/2367 (12549 bytes)
  [INBOX] msg 2359/2367 (10395 bytes)
  [INBOX] msg 2360/2367 (25681 bytes)
  [INBOX] msg 2361/2367 (124612 bytes)
  [INBOX] msg 2362/2367 (4375 bytes)
  [INBOX] msg 2363/2367 (4159 bytes)
  [INBOX] msg 2364/2367 (4024 bytes)
  [INBOX] msg 2365/2367 (11082 bytes)
  [INBOX] msg 2366/2367 (8523 bytes)
  [INBOX] msg 2367/2367 (184397 bytes)
  0 messages (0 bytes) retrieved, 2367 skipped
...(Omit several other mailbox-related logs)

real    16m10.316s
user    0m3.211s
sys     0m0.612s
```

(I haven't add my gmail account for some firewall reason, you may know about)

I add a protocol debug flags in my develop branch, so I can see what it was doing, as below, is to set `Seen` flag over and over again when I run getmail each time.

```text
  ...
  [INBOX] msg 2363/2367 (4159 bytes)
  58:59.86 > b'OGHC2369 UID STORE 3721 FLAGS (\\SEEN)'
  58:59.92 < b'* 2364 FETCH (UID 3721 FLAGS (\\Seen))'
  58:59.92 < b'OGHC2369 OK UID STORE Completed'
  [INBOX] msg 2364/2367 (4024 bytes)
  58:59.92 > b'OGHC2370 UID STORE 3722 FLAGS (\\SEEN)'
  59:00.02 < b'* 2365 FETCH (UID 3722 FLAGS (\\Seen))'
  59:00.02 < b'OGHC2370 OK UID STORE Completed'
  [INBOX] msg 2365/2367 (11082 bytes)
  59:00.02 > b'OGHC2371 UID STORE 3723 FLAGS (\\SEEN)'
  59:00.10 < b'* 2366 FETCH (UID 3723 FLAGS (\\Seen))'
  59:00.10 < b'OGHC2371 OK UID STORE Completed'
  [INBOX] msg 2366/2367 (8523 bytes)
  59:00.10 > b'OGHC2372 UID STORE 3724 FLAGS (\\SEEN)'
  59:00.25 < b'* 2367 FETCH (UID 3724 FLAGS (\\Seen))'
  59:00.25 < b'OGHC2372 OK UID STORE Completed'
  [INBOX] msg 2367/2367 (184397 bytes)
  0 messages (0 bytes) retrieved, 2367 skipped
  59:00.25 > b'OGHC2373 EXPUNGE'
  59:00.65 < b'OGHC2373 OK EXPUNGE Done'
  59:00.65 > b'OGHC2374 CLOSE'
  59:00.74 < b'OGHC2374 OK CLOSE Done'
  59:00.74 > b'OGHC2375 LOGOUT'
  59:00.80 < b'* BYE LOGOUT received'
  59:00.80 BYE response: b'LOGOUT received'
```