### PR TITLE
fix: make mark_read option act same as -ds,

### DIFF
--- a/getmail
+++ b/getmail
@@ -850,8 +850,11 @@ If no flag is given "\Seen" is assumed.
                         defaultopt[option_org] = val
                 imap_override = {}
                 flags,search = imap_search_flags(options.imap_search_n_set)
-                if defaultopt['mark_read'] and ('\\SEEN' not in {x.upper() for x in flags}):
-                    flags += ['\\SEEN']
+                if defaultopt['mark_read']:
+                    if '\\SEEN' not in {x.upper() for x in flags}:
+                        flags += ['\\SEEN']
+                    if 'UNSEEN' not in {x.upper() for x in search}:
+                        search += ['UNSEEN']
                 if flags:
                     imap_override['imap_on_delete'] = '('+' '.join(flags)+')'
                     options.override_delete = True # intention given by -s,


### PR DESCRIPTION
I think I found the correct way to make `mark_read` option act as `-ds,` command line argument. just need add UNSEEN flag to search.

One of the functions of configuration files is to reduce the number of parameters you have to type on the command line, right?

BTW: I cannot reopen #194 because I've force pushed my master branch, and github does not allow to reopen.