### PR TITLE
pop3: Support use_xoauth2.

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -587,6 +587,31 @@ password_command = (&quot;/path/to/password-retriever&quot;, &quot;-p&quot;, &qu
     </li>
 </ul>
 <p>
+    All POP3 retriever types also take the following optional parameters:
+</p>
+<ul>
+    <li>
+        use_xoauth2
+        (<a href="#parameter-boolean">boolean</a>)
+        &mdash; whether to use XOAUTH2 for login with the POP3 server.
+        If not set, normal password-based authentication is used.  This currently
+        supports Gmail and Microsoft Office 365; if anyone extends this to support
+        other POP3 providers, please let me know so I can include such support
+        in getmail.  <strong>Note that using XOAUTH2 is no more secure than a
+        regular getmail configuration with a mode 0600 getmailrc file</strong>.
+        You will need to set <a href="#password_command">password_command</a>
+        as well to tell getmail to invoke the getmail-gmail-xoauth-tokens
+        helper program; that script requires a positional argument to tell it
+        json file where to read the initial tokens from and where it writes the access
+        and refresh tokens to, and the file requires manual initial setup.
+        Keep write access to the json file.
+        This functionality was contributed by Stefan Krah,
+        who has additional information about using it here:
+        <a href="http://www.bytereef.org/howto/oauth2/getmail.html">http://www.bytereef.org/howto/oauth2/getmail.html</a>.
+        See docs/getmailrc-examples.
+    </li>
+</ul>
+<p>
     All IMAP retriever types also take the following optional parameters:
 </p>
 <ul>
@@ -685,7 +710,7 @@ mailboxes = ALL
         <a href="https://docs.python.org/3/library/imaplib.html#imaplib.IMAP4.search">IMAP search</a>.
         Set <pre class="example">imap_search = UNSEEN</pre> to skip read messages.
         The value is case-insensitive. It may be in parentheses.
-        As an example <pre class="example"> 
+        As an example <pre class="example">
 imap_search = Unseen
 imap_on_delete = \Seen</pre>
         fetches only new messages and sets the message flag to <span class="file">SEEN</span> on "delete"
@@ -2547,7 +2572,7 @@ localpart_translate = ('mailhostaccount-', '')
         Has no effect unless <a href="#use_netrc">use_netrc</a> is True.
         Default: unset, which means <a href="#use_netrc">use_netrc</a> will
         read the default netrc file for your system,
-        typically <span class="file">~/.netrc</span>, unless 
+        typically <span class="file">~/.netrc</span>, unless
         <span class="file">NETRC</span> or <span class="file">CURLOPT_NETRC_FILE</span>
         is defined.
     </li>

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -367,6 +367,24 @@ Creating a getmail rc file
  password_command = ("/path/to/password-retriever", "-p", "myaccount@example.org")
         
 
+   All POP3 retriever types also take the following optional parameters:
+
+     * use_xoauth2 (boolean) — whether to use XOAUTH2 for login with the POP3
+       server. If not set, normal password-based authentication is used. This
+       currently supports Gmail and Microsoft Office 365; if anyone extends
+       this to support other POP3 providers, please let me know so I can
+       include such support in getmail. Note that using XOAUTH2 is no more
+       secure than a regular getmail configuration with a mode 0600 getmailrc
+       file. You will need to set password_command as well to tell getmail to
+       invoke the getmail-gmail-xoauth-tokens helper program; that script
+       requires a positional argument to tell it json file where to read the
+       initial tokens from and where it writes the access and refresh tokens
+       to, and the file requires manual initial setup. Keep write access to
+       the json file. This functionality was contributed by Stefan Krah, who
+       has additional information about using it here:
+       http://www.bytereef.org/howto/oauth2/getmail.html. See
+       docs/getmailrc-examples.
+
    All IMAP retriever types also take the following optional parameters:
 
      * mailboxes (tuple of quoted strings) — a list of mailbox paths to
@@ -440,7 +458,6 @@ Creating a getmail rc file
        to skip read messages. The value is case-insensitive. It may be in
        parentheses. As an example
 
- 
  imap_search = Unseen
  imap_on_delete = \Seen
 

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -41,6 +41,7 @@ import poplib
 import imaplib
 import re
 import select
+import base64
 
 try:
     # do we have a recent pykerberos?
@@ -1219,6 +1220,12 @@ class POP3RetrieverBase(RetrieverSkeleton):
             if self.conf['use_apop']:
                 self.conn.apop(self.conf['username'],
                                self.conf['password'])
+            elif self.conf['use_xoauth2']:
+                # octal 1 / ctrl-A used as separator
+                auth = 'user=%s\1auth=Bearer %s\1\1' % (self.conf['username'],
+                                                        self.conf['password'])
+                auth = base64.b64encode(auth.encode()).decode()
+                self.conn._shortcmd('AUTH XOAUTH2 %s' % auth)
             else:
                 self.conn.user(self.conf['username'])
                 self.conn.pass_(self.conf['password'])
@@ -2027,4 +2034,3 @@ class MultidropIMAPRetrieverBase(IMAPRetrieverBase):
             )
         msg.recipient = address_no_brackets(line.strip())
         return msg
-

--- a/getmailcore/retrievers.py
+++ b/getmailcore/retrievers.py
@@ -66,6 +66,7 @@ class SimplePOP3Retriever(POP3RetrieverBase, POP3initMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         ConfBool(name='use_apop', required=False, default=False),
         ConfBool(name='delete_dup_msgids', required=False, default=False),
     )
@@ -100,6 +101,7 @@ class SimplePOP3SSLRetriever(POP3RetrieverBase, POP3SSLinitMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         ConfBool(name='use_apop', required=False, default=False),
         ConfBool(name='delete_dup_msgids', required=False, default=False),
         ConfFile(name='keyfile', required=False, default=None),
@@ -178,6 +180,7 @@ class BrokenUIDLPOP3Retriever(BrokenUIDLPOP3RetrieverBase, POP3initMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         ConfBool(name='use_apop', required=False, default=False),
     )
     received_with = 'POP3'
@@ -209,6 +212,7 @@ class BrokenUIDLPOP3SSLRetriever(BrokenUIDLPOP3RetrieverBase, POP3SSLinitMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         ConfBool(name='use_apop', required=False, default=False),
         ConfFile(name='keyfile', required=False, default=None),
         ConfFile(name='certfile', required=False, default=None),
@@ -247,6 +251,7 @@ class MultidropPOP3Retriever(MultidropPOP3RetrieverBase, POP3initMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         ConfBool(name='use_apop', required=False, default=False),
         ConfString(name='envelope_recipient'),
     )
@@ -281,6 +286,7 @@ class MultidropPOP3SSLRetriever(MultidropPOP3RetrieverBase, POP3SSLinitMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         ConfBool(name='use_apop', required=False, default=False),
         ConfString(name='envelope_recipient'),
         ConfFile(name='keyfile', required=False, default=None),
@@ -329,6 +335,7 @@ class MultidropSDPSRetriever(SimplePOP3Retriever, POP3initMixIn):
         ConfString(name='username'),
         ConfPassword(name='password', required=False, default=None),
         ConfTupleOfStrings(name='password_command', required=False, default=()),
+        ConfBool(name='use_xoauth2', required=False, default=False),
         # Demon apparently doesn't support APOP
         ConfBool(name='use_apop', required=False, default=False),
     )
@@ -563,4 +570,3 @@ class MultidropIMAPSSLRetriever(MultidropIMAPRetrieverBase, IMAPSSLinitMixIn):
         self.log.trace()
         self.log.info('MultidropIMAPSSLRetriever(%s)' % self._confstring()
                       + os.linesep)
-


### PR DESCRIPTION
Adds support for use_xoauth2 configuration and OAuth2 support to POP3 retrievers.

* getmailcore/_retrieverbases.py (POP3RetrieverBase.initialize): Handle use_xoauth2.
* getmailcore/retrievers.py (SimplePOP3Retriever, SimplePOP3SSLRetriever), (BrokenUIDLPOP3Retriever, BrokenUIDLPOP3SSLRetriever), (MultidropPOP3Retriever, MultidropPOP3SSLRetriever), (MultidropSDPSRetriever): New ConfBool `use_xoauth2'.
* docs/configuration.html, docs/configuration.txt: Document it.