### PR TITLE
Remove port number 8083 from example No. 13 in getmailrc-example

### DIFF
--- a/docs/getmailrc-examples
+++ b/docs/getmailrc-examples
@@ -359,7 +359,7 @@ password_command = ("getmail-gmail-xoauth-tokens", "/path/to/your/users/getmail/
 # Select "New Registration"
 # Enter a project name, eg "getmail".
 # Select "Accounts in this organizational directory only (Single tenant)" from "Supported account types"
-# Select type "Web" and enter "http://localhost:8083" for "Redirect URI"
+# Select type "Web" and enter "http://localhost" for "Redirect URI"
 # Select "Register"
 #
 # Now, from the new App's details page, make a note of:


### PR DESCRIPTION
I removed port number 8083 from example 13. On August 12, 2024, I tested on Azure and confirmed that it was not necessary to have port number 8083 on the URL for redirection_uri when creating an Azure app. See also the suggestion from @ykasap https://github.com/getmail6/getmail6/pull/204#issuecomment-2274880089.