### PR TITLE
Pyp2 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,18 +45,18 @@ check: lint
 .PHONY: dist
 dist: doc
 	echo "need sudo to create wheel"
-	sudo python setup.py bdist_wheel
+	sudo python setup.py bdist_wheel sdist
 	echo "note:"
 	echo "use ./pypi.sh to upload to PYPI"
 
 # use ./pypi.sh to upload to PYPI
 .PHONY: up6
 up6: dist
-	twine upload dist/`ls dist -rt | tail -1` -u__token__ -p`pass show pypi.org/getmail6_api_token`
+	twine upload dist/`ls dist -rt *.whl | tail -1` dist/`ls dist -rt *.tar.gz | tail -1` -u__token__ -p`pass show pypi.org/getmail6_api_token`
 
 .PHONY: up
 up: dist
-	twine upload dist/`ls dist -rt | tail -1` -u__token__ -p`pass show pypi.org/getmail_api_token`
+	twine upload dist/`ls dist -rt *.whl | tail -1` dist/`ls dist -rt *.tar.gz | tail -1` -u__token__ -p`pass show pypi.org/getmail_api_token`
 
 .PHONY: tag
 tag: dist

--- a/getmailcore/__init__.py
+++ b/getmailcore/__init__.py
@@ -17,7 +17,7 @@ You should have received a copy of the license in the file COPYING.
 import sys
 
 __version__ = '6.19.04'
-__license__ = 'GNU GPL version 2'
+__license__ = 'GPL-2.0'
 
 __py_required__ = '2.7.16'
 __py_required_hex__ = 0x20710f0


### PR DESCRIPTION
pyp2spec is a tool for generating Fedora packages from pypi.

When running it for getmail6 I got some errors:

* License is an invalid SPDX expression
* sdist isn't uploaded to pypi

This PR contains the fixes for these errors, I hope you can merge these changes and do a release.