### PR TITLE
Increase imap efficiency through UID cache #219

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -2577,6 +2577,16 @@ localpart_translate = ('mailhostaccount-', '')
         is defined.
     </li>
     <li>
+        <a name="imap_cache_uid">imap_cache_uid</a>
+        (<a href="#parameter-boolean">string</a>)
+        &mdash; enables specific functionality and set the file for the cache.
+        Specifically, this enables an efficiency feature where the highest imap UID
+        previously seen will be used as the starting position for downloading new files.
+        This dramatically increases efficiency of network utilization for large upstream
+        mailboxes when delete (see next parameter) is not used since the same messages
+        are not downloaded over and over and over again, only to be thrown away.
+    </li>
+    <li>
         delete
         (<a href="#parameter-boolean">boolean</a>)
         &mdash; if set, getmail will delete messages after retrieving and

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -1458,6 +1458,14 @@ Creating a getmail rc file
        effect unless use_netrc is True. Default: unset, which means use_netrc
        will read the default netrc file for your system, typically ~/.netrc,
        unless NETRC or CURLOPT_NETRC_FILE is defined.
+     * imap_cache_uid (string) — enables specific functionality and set
+       the file for the cache. Specifically, this enables an efficiency
+       feature where the highest imap UID previously seen will be used as the
+       starting position for downloading new files. This dramatically
+       increases efficiency of network utilization for large upstream
+       mailboxes when delete (see next parameter) is not used since the same
+       messages are not downloaded over and over and over again, only to be
+       thrown away.
      * delete (boolean) — if set, getmail will delete messages after
        retrieving and successfully delivering them. If unset, getmail will
        leave messages on the server after retrieving them. Default: False.

--- a/getmail
+++ b/getmail
@@ -89,6 +89,7 @@ options_int = (
 options_str = (
     'message_log',
     'netrc_file',
+    'imap_cache_uid',
 )
 
 options_defaults = {
@@ -111,6 +112,7 @@ options_defaults = {
     'fingerprint' : False,
     'use_netrc' : False,
     'netrc_file' : None,
+    'imap_cache_uid' : None,
     'to_oldmail_on_each_mail' : False,
     'only_oldmail_file': False,
     'skip_imap_fetch_size' : False,
@@ -774,6 +776,7 @@ If no flag is given "\Seen" is assumed.
                 'fingerprint' : options_defaults['fingerprint'],
                 'use_netrc' : options_defaults['use_netrc'],
                 'netrc_file' : options_defaults['netrc_file'],
+                'imap_cache_uid' : options_defaults['imap_cache_uid'],
                 'to_oldmail_on_each_mail' : options_defaults['to_oldmail_on_each_mail'],
                 'only_oldmail_file' : options_defaults['only_oldmail_file'],
                 'skip_imap_fetch_size' : options_defaults['skip_imap_fetch_size'],
@@ -940,6 +943,8 @@ If no flag is given "\Seen" is assumed.
                     for (name, value) in imap_override.items():
                         if name in retriever:
                             retriever.conf[name] = value
+                    retriever.conf['imap_cache_uid'] = defaultopt['imap_cache_uid']
+
                     retriever.checkconf()
                 except getmailOperationError as o:
                     log.error('Error initializing retriever: %s\n' % o)

--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -1354,6 +1354,7 @@ class IMAPRetrieverBase(RetrieverSkeleton):
         self.msgsizes = {}
         self.oldmail = {}
         self.__delivered = {}
+        self._mboxmaxuid = 1
 
     def checkconf(self):
         RetrieverSkeleton.checkconf(self)
@@ -1499,7 +1500,54 @@ class IMAPRetrieverBase(RetrieverSkeleton):
         self.msgsizes = {}
         self.oldmail = {}
         self.__delivered = {}
+        self._mboxmaxuid = 1
         self.conn.close()
+
+    def _fileexpand(self, filename):
+        getmaildir = self.conf['getmaildir']
+        f = os.path.expanduser(filename)
+        if f[0] != "/" and getmaildir:
+            f = os.path.join(getmaildir, f)
+        return(f)
+
+    def _sane_validity(self, uidvalidity):
+        return uidvalidity.replace(" ","_")
+
+    def _findmaxuid(self, mailbox, uidvalidity):
+        self._mboxmaxuid = 1
+        self._mboxmaxuid_changed = False
+        if not self.conf['imap_cache_uid']:
+            return
+        if not uidvalidity:
+            return
+        try:
+            with open(self._fileexpand(self.conf['imap_cache_uid'])) as C:
+                for line in C:
+                    (mbox, oldvalidity, uid) = line.split(" ")
+                    if mbox == mailbox:
+                        if oldvalidity == self._sane_validity(uidvalidity):
+                            self._mboxmaxuid = int(uid)
+                        return
+        except ValueError:
+            return
+        except FileNotFoundError:
+            return
+
+    def _savemaxuid(self, mailbox, uidvalidity):
+        if not self.conf['imap_cache_uid'] or not self._mboxmaxuid_changed or not uidvalidity:
+            return
+        uidcache = {}
+        try:
+            with open(self._fileexpand(self.conf['imap_cache_uid'])) as C:
+                for line in C:
+                    (mbox, oldvalidity, uid) = line.split(" ")
+                    uidcache[mbox] = line
+        except FileNotFoundError:
+            pass
+        uidcache[mailbox] = " ".join((mailbox, self._sane_validity(uidvalidity), str(self._mboxmaxuid)))+"\n"
+        with open(self._fileexpand(self.conf['imap_cache_uid']),"w") as C:
+            for line in uidcache.values():
+                print(line, file=C, end="")
 
     def select_mailbox(self, mailbox):
         self.log.trace()
@@ -1554,6 +1602,7 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                        % (mailbox, count) + os.linesep)
         self.mailbox = mailbox
         self.uidvalidity = uidvalidity
+        self._findmaxuid(mailbox, uidvalidity)
 
         imap_search = self.conf['imap_search']
         if imap_search:
@@ -1565,21 +1614,27 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                     msgs = msgs.decode()
                 self._getmsglist(msgs)
         else:
-            self._getmsglist(count)
+            self._getmsglist(count, start=self._mboxmaxuid)
+
+        self._savemaxuid(mailbox, uidvalidity)
 
         return count
 
-    def _getmsglist(self, msgcount):
+    def _getmsglist(self, msgcount, start=1):
         self.log.trace()
+        oldest = None
         try:
             if msgcount:
                 # Get UIDs and sizes for all messages in mailbox
-                response = self._parse_imapcmdresponse(
-                    'FETCH',
-                    isinstance(msgcount,str) and msgcount or '1:%d'%msgcount,
-                    ('(UID)' if self.app_options['skip_imap_fetch_size'] else
-                    '(UID RFC822.SIZE)')
-                )
+                if start > 1:
+                    fetchcmd=['UID', 'FETCH']
+                    fetchcmd.append("%d:*"%start)
+                else:
+                    fetchcmd=['FETCH']
+                    fetchcmd.append(isinstance(msgcount,str) and msgcount or '1:%d'%(msgcount))
+                fetchcmd.append(('(UID)' if self.app_options['skip_imap_fetch_size'] else
+                                 '(UID RFC822.SIZE)'))
+                response = self._parse_imapcmdresponse(*fetchcmd)
                 for line in response:
                     if not line:
                         # One user had a server that returned a null response
@@ -1622,6 +1677,16 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                     # detect old-style oldmail files.  Can occur with IMAP, at
                     # least with some servers.
                     uid = r['uid'].replace('/', '-')
+
+                    try:
+                        nuid = int(uid)
+                        if (nuid > self._mboxmaxuid):
+                            self._mboxmaxuid = nuid
+                            self._mboxmaxuid_changed = True
+                    except ValueError:
+                        # Presumably non-numeric UID, which should be illegal but according to comment above it can happen
+                        pass
+
                     msgid = '%s/%s' % (self.uidvalidity, uid)
                     self._mboxuids[msgid] = r['uid']
                     self._mboxuidorder.append(msgid)
@@ -1630,14 +1695,34 @@ class IMAPRetrieverBase(RetrieverSkeleton):
                         self.app_options['skip_imap_fetch_size']
                                         else int(r['rfc822.size']))
 
+                # Figure out what the oldest UID is
+                if start > 1:
+                    response = self._parse_imapcmdresponse('FETCH','1','(UID)')
+                    for line in response:
+                        if not line:
+                            continue
+                        r = self._parse_imapattrresponse(line)
+                        if 'uid' not in r:
+                            continue
+                        uid = r['uid'].replace('/', '-')
+                        msgid = '%s/%s' % (self.uidvalidity, uid)
+                        oldest = msgid
+
             # Remove messages from state file that are no longer in mailbox,
             # but only if the timestamp for them are old (30 days for now).
             # This is because IMAP users can have one state file but multiple
             # IMAP folders in different configuration rc files.
+            if oldest:
+                (ov,ou) = oldest.split('/')
             for msgid in list(self.oldmail):
                 timestamp = self.oldmail[msgid]
                 age = self.timestamp - timestamp
                 if msgid not in self.msgsizes and age > VANISHED_AGE:
+                    # Don't delete oldmails that might still be around if we are only doing partial reads of the mailbox
+                    if oldest:
+                        (mv,mu) = msgid.split('/')
+                        if (ov == mv and ou < mu):
+                            continue
                     self.log.debug('removing vanished old message id %s' % msgid
                                    + os.linesep)
                     del self.oldmail[msgid]


### PR DESCRIPTION
Patch to close bug #219.

New configuration parameter imap_cache_uid.

When set (to a relative or absolute filename), it will cache the highest UID seen so that old UIDs are not fetched over and over again.