### PR TITLE
Publish to pypi workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/getmail
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Make sure tag matches version
+        run: "[[ $(git describe --tags --exact-match) = $(python -c 'import getmailcore ; print(getmailcore.__version__)') ]]"
+
+      - name: Build project
+        run: |
+          sed -i -e "s/name.*=.*getmail6./name = 'getmail'/g" setup.py
+          make dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish6.yml
+++ b/.github/workflows/publish6.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/getmail6
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Make sure tag matches version
+        run: "[[ $(git describe --tags --exact-match) = $(python -c 'import getmailcore ; print(getmailcore.__version__)') ]]"
+
+      - name: Build project
+        run: make dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This workflow automatically build and publish getmail to PyPI and does digital attestation when a tag gets created.

I also included a step to check of the tag matches the version in getmailcore (I always forget to update that version).

For this to work you must allow/configure this github repository to publish on pypi.org (you can easily do this by logging into pypi.org, navigate to the getmail projects and open the "publishing" setting).

The advantage of this is that you don't have to mess with tokens and the digital attestation proves that the build was done using this workflow (and wasn't tampered with).