### PR TITLE
Add Apache-2.0 license

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -14,6 +14,7 @@ Classifier: Environment :: Console
 Classifier: Intended Audience :: End Users/Desktop
 Classifier: Intended Audience :: System Administrators
 Classifier: License :: OSI Approved :: GNU General Public License (GPL)
+Classifier: License :: OSI Approved :: Apache Software License
 Classifier: Natural Language :: English
 Classifier: Operating System :: OS Independent
 Classifier: Operating System :: POSIX

--- a/README
+++ b/README
@@ -18,6 +18,9 @@ getmail is Copyright (C) 1998-2025 Charles Cazabon and others.
 getmail is licensed for use under the GNU General Public License version 2 (only).
 See ``docs/COPYING`` for specific terms and distribution information.
 
+getmail-gmail-xoauth-tokens is Copyright 2012 Google Inc.
+getmail-gmail-xoauth-tokens is licensed for under the Apache License, Version 2.0
+
 Bugs
 ====
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: GNU General Public License (GPL)',
+        'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Operating System :: POSIX',


### PR DESCRIPTION
It seems like `getmail-gmail-xoauth-tokens` isn't GPL-2.0 licensed, add Apache Software License to PKG-INFO, setup.py and add some notes to the README.