### PR TITLE
use multiprocessing start method for for tests

### DIFF
--- a/test/test_mock_servers.py
+++ b/test/test_mock_servers.py
@@ -12,6 +12,10 @@ from typing import NamedTuple
 import pytest
 import email.message
 
+@pytest.fixture(scope="session", autouse=True)
+def always_spawn():
+    multiprocessing.set_start_method("fork")
+
 class FetchSize(NamedTuple):
     uid: int
     size: int


### PR DESCRIPTION
Thanks for releasing 6.19.9!

I noticed some of the forking has changed to multiprocessing, which is a great improvement!

I hope all forking can be removed at some point, do you need some help with that?

It only seems like that nested multiprocessing (using spawn) isn't supported, this PR fixes the mock server tests by switching to fork (for the tests).