### PR TITLE
Retry LMTP connection on SMTPSenderRefused exception

### DIFF
--- a/getmailcore/destinations.py
+++ b/getmailcore/destinations.py
@@ -721,7 +721,7 @@ class MDA_lmtp(DeliverySkeleton):
     def __send(self, msg, sender, recipient, __retrying=False):
         try:
             rcpt = self.server.send_message(msg, sender, recipient)
-        except smtplib.SMTPServerDisconnected as err:
+        except (smtplib.SMTPServerDisconnected, smtplib.SMTPSenderRefused) as err:
             if __retrying:
                 raise
             else:


### PR DESCRIPTION
When there is a long delay between incoming messages the LMTP server will often disconnect without notifying the getmail LMTP client. When getmail attempts sending a new message on the closed socket it will fail with `SMTPSenderRefused`.

This PR causes getmail6 to retry that send operation once rather than immediately raising an exception.