### PR TITLE
Fix mangled method argument

### DIFF
--- a/getmailcore/destinations.py
+++ b/getmailcore/destinations.py
@@ -718,16 +718,16 @@ class MDA_lmtp(DeliverySkeleton):
     def showconf(self):
         self.log.info('%s(%s)' % (type(self).__name__, self._confstring()))
 
-    def __send(self, msg, sender, recipient, __retrying=False):
+    def __send(self, msg, sender, recipient, _retrying=False):
         try:
             rcpt = self.server.send_message(msg, sender, recipient)
         except (smtplib.SMTPServerDisconnected, smtplib.SMTPSenderRefused) as err:
-            if __retrying:
+            if _retrying:
                 raise
             else:
                 self.log.info('Lost connection to LMTP server, reconnecting')
                 self.__connect()
-                return self.__send(msg, sender, recipient, __retrying=True)
+                return self.__send(msg, sender, recipient, _retrying=True)
         except smtplib.SMTPRecipientsRefused as err:
             rcpt = err.recipients
         except smtplib.SMTPException as err:

--- a/test/test.py
+++ b/test/test.py
@@ -1,11 +1,15 @@
 import sys
 import textwrap
 import subprocess
+import unittest.mock as mock
 
 from getmailcore.message import Message
 from getmailcore.exceptions import *
+from getmailcore.destinations import MDA_lmtp
+import getmailcore.logging as getmail_logging
 
 import os, smtplib, ssl
+import pytest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.message import EmailMessage
@@ -134,4 +138,80 @@ def test_imap_ssl_parameters(capfd):
     except SystemExit:
         c = capfd.readouterr()
         assert c.err.index("AUTHENTICATIONFAILED") > 0
+
+
+@pytest.fixture(autouse=False)
+def clean_logger():
+    """Clear stale Logger handlers that may have been set up by other tests."""
+    getmail_logging.Logger.clearhandlers()
+    yield
+    getmail_logging.Logger.clearhandlers()
+
+
+def _make_lmtp_msg(sender='sender@example.com', recipient='recipient@example.com'):
+    msg = mock.MagicMock()
+    msg.sender = sender
+    msg.recipient = recipient
+    return msg
+
+
+def test_lmtp_successful_delivery():
+    with mock.patch('smtplib.LMTP') as mock_lmtp_cls:
+        mock_server = mock.MagicMock()
+        mock_lmtp_cls.return_value = mock_server
+        mock_server.send_message.return_value = {}
+
+        dest = MDA_lmtp(host='localhost', port=24)
+        dest._deliver_message(_make_lmtp_msg(), True, True)
+
+        mock_lmtp_cls.assert_called_once_with('localhost', 24)
+        mock_server.send_message.assert_called_once()
+
+
+def test_lmtp_retry_on_disconnected(clean_logger):
+    with mock.patch('smtplib.LMTP') as mock_lmtp_cls:
+        mock_server = mock.MagicMock()
+        mock_lmtp_cls.return_value = mock_server
+        mock_server.send_message.side_effect = [
+            smtplib.SMTPServerDisconnected('connection lost'),
+            {},
+        ]
+
+        dest = MDA_lmtp(host='localhost', port=24)
+        dest._deliver_message(_make_lmtp_msg(), True, True)
+
+        # Initial connect in initialize() + one reconnect on retry
+        assert mock_lmtp_cls.call_count == 2
+        assert mock_server.send_message.call_count == 2
+
+
+def test_lmtp_retry_on_sender_refused(clean_logger):
+    with mock.patch('smtplib.LMTP') as mock_lmtp_cls:
+        mock_server = mock.MagicMock()
+        mock_lmtp_cls.return_value = mock_server
+        mock_server.send_message.side_effect = [
+            smtplib.SMTPSenderRefused(550, b'Sender refused', b'sender@example.com'),
+            {},
+        ]
+
+        dest = MDA_lmtp(host='localhost', port=24)
+        dest._deliver_message(_make_lmtp_msg(), True, True)
+
+        assert mock_lmtp_cls.call_count == 2
+        assert mock_server.send_message.call_count == 2
+
+
+def test_lmtp_no_infinite_retry(clean_logger):
+    with mock.patch('smtplib.LMTP') as mock_lmtp_cls:
+        mock_server = mock.MagicMock()
+        mock_lmtp_cls.return_value = mock_server
+        mock_server.send_message.side_effect = smtplib.SMTPServerDisconnected('connection lost')
+
+        dest = MDA_lmtp(host='localhost', port=24)
+
+        with pytest.raises(smtplib.SMTPServerDisconnected):
+            dest._deliver_message(_make_lmtp_msg(), True, True)
+
+        # Exactly two send attempts: initial + one retry (no further retries)
+        assert mock_server.send_message.call_count == 2
 


### PR DESCRIPTION
My previous commit (#257) exposed a deeper problem in the retry logic:

The `_send` method uses a `__retrying` parameter (double-underscore) to prevent infinite retry loops. Python's name mangling transforms `__retrying` in the method definition to `_MDA_lmtp__retrying`, but keyword argument names in function calls are not subject to name mangling. So the recursive call `self.__send(msg, sender, recipient, __retrying=True)` passes the keyword `__retrying` while the function expects `_MDA_lmtp__retrying`, causing an error like this:

```
     TypeError: MDA_lmtp.__send() got an unexpected keyword argument '__retrying'
```

The fix is to refactor the keyword arg `__retrying` to `_retrying`. I also added unit tests to ensure the function runs end-to-end without errors.