### PR TITLE
test: skip test_imap_full when running as root

### DIFF
--- a/test/test_mock_servers.py
+++ b/test/test_mock_servers.py
@@ -385,6 +385,8 @@ def test_imap(destination_type, destination_init):
         p.join()
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="test_imap_full fails when run as root due to security check")
+
 def test_imap_full():
     mock_tcp = MockTCP()
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
The test_imap_full test spawns an external command (/bin/cat) via a
filter in the getmailrc config. When run as root, getmail's security
check (ForkingBase.some_security()) blocks execution of external
commands as a safety measure.

Add a pytest.mark.skipif decorator to skip the test when running as
root (euid == 0), which is common in Docker containers and CI
environments.
