### PR TITLE
Fix crash when unsolicited IMAP FLAGS response precedes FETCH body (delete=true)

### DIFF
--- a/getmailcore/_retrieverbases.py
+++ b/getmailcore/_retrieverbases.py
@@ -1830,7 +1830,21 @@ class IMAPRetrieverBase(RetrieverSkeleton):
             # message when requested.
             try:
                 try:
-                    sbody = response[0][1]
+                    # response is a list of IMAP FETCH response items. Most
+                    # entries are (metadata, message-body) tuples, but the
+                    # server may also interleave unsolicited responses (e.g.
+                    # a FLAGS update sent right after a STORE for delete=true)
+                    # as plain bytes instead of a tuple.  Blindly taking
+                    # response[0][1] can therefore pick up an unsolicited
+                    # response and index into raw bytes, yielding an int
+                    # instead of the message body.  Find the first entry
+                    # that actually looks like a (metadata, body) tuple.
+                    sbody = next(
+                        (item[1] for item in response
+                         if isinstance(item, tuple) and len(item) > 1
+                         and isinstance(item[1], bytes)),
+                        None
+                    )
                 except Exception as o:
                     sbody = None
                 if not sbody:

--- a/test/test.py
+++ b/test/test.py
@@ -215,3 +215,61 @@ def test_lmtp_no_infinite_retry(clean_logger):
         # Exactly two send attempts: initial + one retry (no further retries)
         assert mock_server.send_message.call_count == 2
 
+
+
+from getmailcore._retrieverbases import IMAPRetrieverBase
+
+
+def _make_imap_retriever():
+    r = IMAPRetrieverBase.__new__(IMAPRetrieverBase)
+    r.log = mock.MagicMock()
+    r.conf = {'record_mailbox': False}
+    r.conn = mock.MagicMock()
+    r.conn.capabilities = []
+    r._getmboxuidbymsgid = lambda msgid: b'1'
+    return r
+
+
+def test_getmsgpartbyid_skips_unsolicited_response():
+    """Regression test for issue #278.
+
+    When delete=true, the IMAP server may send an unsolicited FLAGS
+    response (plain bytes) ahead of the real (metadata, body) FETCH
+    tuple. Naively taking response[0][1] indexes into those bytes and
+    returns an int instead of the message body, crashing downstream
+    with AttributeError. The retriever should skip such entries and
+    find the actual (metadata, body) tuple wherever it appears.
+    """
+    r = _make_imap_retriever()
+    r._parse_imapuidcmdresponse = lambda cmd, *args: [
+        b'1 (FLAGS (\\Seen \\Deleted))',
+        (b'1 (UID 1 RFC822 {35}', b'Return-Path: <a@b.com>\r\n\r\nbody'),
+    ]
+
+    msg = r._getmsgpartbyid('1', '(RFC822)')
+
+    assert msg.content()['Return-Path'] == '<a@b.com>'
+
+
+def test_getmsgpartbyid_normal_response_unaffected():
+    """Control: a well-formed response (no unsolicited entries) still works."""
+    r = _make_imap_retriever()
+    r._parse_imapuidcmdresponse = lambda cmd, *args: [
+        (b'1 (UID 1 RFC822 {35}', b'Return-Path: <c@d.com>\r\n\r\nbody'),
+        b')',
+    ]
+
+    msg = r._getmsgpartbyid('1', '(RFC822)')
+
+    assert msg.content()['Return-Path'] == '<c@d.com>'
+
+
+def test_getmsgpartbyid_no_body_raises_retrieval_error():
+    """Control: if no entry has a usable body, a getmailRetrievalError is raised."""
+    r = _make_imap_retriever()
+    r._parse_imapuidcmdresponse = lambda cmd, *args: [
+        b'1 (FLAGS (\\Seen \\Deleted))',
+    ]
+
+    with pytest.raises(getmailRetrievalError):
+        r._getmsgpartbyid('1', '(RFC822)')


### PR DESCRIPTION
## Problem

A temporary DNS or network failure during OAuth token refresh is misclassified as an authentication failure:

```
Authentication failed while fetching tado_x data: Authentication failed: Network error during token refresh: Cannot connect to host login.tado.com:443 ssl:default [DNS server returned general failure]. Please re-authenticate.
```

This forces Home Assistant into a persistent reauthentication flow, and the integration doesn't recover automatically once connectivity returns -- even though the refresh token itself was never rejected by Tado.

Fixes #80.

## Root cause

`refresh_access_token()` catches every `aiohttp.ClientError` (DNS resolution failure, connection reset, TLS handshake failure, server timeout, etc.) and re-raises it as `TadoXAuthError`:

```python
except aiohttp.ClientError as err:
    raise TadoXAuthError(f"Network error during token refresh: {err}") from err
```

The coordinator converts `TadoXAuthError` into `ConfigEntryAuthFailed`, which is meant for genuine credential rejection, not connectivity issues. A network-level failure here means Tado was never actually reached, so nothing is known about whether the refresh token is still valid.

## Fix

Raise `TadoXApiError` instead of `TadoXAuthError` when `aiohttp.ClientError` occurs. The coordinator already converts `TadoXApiError` into `UpdateFailed`, which is the transient-failure path Home Assistant retries on the next coordinator update -- the same treatment `_request()` already gives network errors elsewhere in this file.

`TadoXAuthError` is still raised, unchanged, whenever Tado actually responds with a non-200 status (e.g. 400 `invalid_grant`, 401) -- that remains a genuine credential rejection and correctly triggers reauthentication.

## Testing

Added `tests/test_refresh_access_token_network_errors.py`, covering the regression tests suggested in the issue: DNS failure, connection reset, and server timeout during refresh now raise `TadoXApiError` (not `TadoXAuthError`); HTTP 400 and HTTP 401 responses still correctly raise `TadoXAuthError`; and a successful refresh still updates the stored tokens as before.

Loads `custom_components/tado_x/api.py` directly (bypassing the package `__init__.py`, which imports Home Assistant) so these tests run without a Home Assistant test environment.

Confirmed each network-error test fails against the pre-fix code with the exact reported `TadoXAuthError`, and passes after the fix.
